### PR TITLE
Expose disconnection

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -581,7 +581,6 @@ public:
 
 private:
   void onConnection(const std::shared_ptr<Tcp::Peer> &peer) override;
-  void onDisconnection(const std::shared_ptr<Tcp::Peer> &peer) override;
   void onInput(const char *buffer, size_t len,
                const std::shared_ptr<Tcp::Peer> &peer) override;
   RequestParser &getParser(const std::shared_ptr<Tcp::Peer> &peer) const;

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -964,8 +964,6 @@ void Handler::onConnection(const std::shared_ptr<Tcp::Peer> &peer) {
   peer->putData(ParserData, std::make_shared<RequestParser>(maxRequestSize_));
 }
 
-void Handler::onDisconnection(const std::shared_ptr<Tcp::Peer> & /*peer*/) {}
-
 void Handler::onTimeout(const Request & /*request*/,
                         ResponseWriter /*response*/) {}
 


### PR DESCRIPTION
Http::Handler made the onDisconnection(..) callback private. This PR removes that mask so that derived classes can get notification of disconnections.

This is handy for cases where requests might take a while to complete, and if a client disconnects it's possible to get notified to stop processing.

- Added basic functionality
- Added test case in http_server_tests.cc
- Verified all parts compile
- Verified all tests pass (gcc 10.2.1)