### PR TITLE
Adding a Peer ID to identify connections

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -581,7 +581,6 @@ public:
 
 private:
   void onConnection(const std::shared_ptr<Tcp::Peer> &peer) override;
-  void onDisconnection(const std::shared_ptr<Tcp::Peer> &peer) override;
   void onInput(const char *buffer, size_t len,
                const std::shared_ptr<Tcp::Peer> &peer) override;
   RequestParser &getParser(const std::shared_ptr<Tcp::Peer> &peer) const;

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -415,6 +415,12 @@ public:
 
   ResponseWriter clone() const;
 
+  std::shared_ptr<Tcp::Peer> getPeer() const {
+      if (auto sp = peer_.lock())
+          return sp;
+      return nullptr;
+  }
+
 private:
   ResponseWriter(Tcp::Transport *transport, Request request, Handler *handler,
                  std::weak_ptr<Tcp::Peer> peer);

--- a/include/pistache/peer.h
+++ b/include/pistache/peer.h
@@ -48,6 +48,7 @@ public:
   std::shared_ptr<Http::Parser> tryGetData(std::string name) const;
 
   Async::Promise<ssize_t> send(const RawBuffer &buffer, int flags = 0);
+  size_t getID() const;
 
 protected:
   Peer(Fd fd, const Address &addr, void *ssl);
@@ -64,6 +65,7 @@ private:
   std::unordered_map<std::string, std::shared_ptr<Http::Parser>> data_;
 
   void *ssl_ = nullptr;
+  const size_t id_;
 };
 
 std::ostream &operator<<(std::ostream &os, Peer &peer);

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -964,8 +964,6 @@ void Handler::onConnection(const std::shared_ptr<Tcp::Peer> &peer) {
   peer->putData(ParserData, std::make_shared<RequestParser>(maxRequestSize_));
 }
 
-void Handler::onDisconnection(const std::shared_ptr<Tcp::Peer> & /*peer*/) {}
-
 void Handler::onTimeout(const Request & /*request*/,
                         ResponseWriter /*response*/) {}
 

--- a/src/common/peer.cc
+++ b/src/common/peer.cc
@@ -18,6 +18,8 @@
 namespace Pistache {
 namespace Tcp {
 
+std::atomic<size_t> idCounter{0};
+
 namespace {
 struct ConcretePeer : Peer {
   ConcretePeer() = default;
@@ -26,7 +28,7 @@ struct ConcretePeer : Peer {
 } // namespace
 
 Peer::Peer(Fd fd, const Address &addr, void *ssl)
-    : fd_(fd), addr(addr), ssl_(ssl) {}
+    : fd_(fd), addr(addr), ssl_(ssl), id_(idCounter++) {}
 
 Peer::~Peer() {
 #ifdef PISTACHE_USE_SSL
@@ -66,6 +68,7 @@ const std::string &Peer::hostname() {
 }
 
 void *Peer::ssl() const { return ssl_; }
+size_t Peer::getID() const { return id_; }
 
 int Peer::fd() const {
   if (fd_ == -1) {

--- a/tests/http_server_test.cc
+++ b/tests/http_server_test.cc
@@ -438,8 +438,7 @@ struct ClientCountingHandler : public Http::Handler {
 
   void onDisconnection(const std::shared_ptr<Tcp::Peer> &peer) override {
     ++counter_;
-    std::cout << "[server] Disconnect from " << peer->address().host() << " now at " << counter_ << std::endl;
-    std::cout << "[server] Disconnect from " << peer->getID() << " now at " << std::endl;
+    std::cout << "[server] Disconnect from peer ID " << peer->getId() << " connecting from " << peer->address().host() << "; counter now at " << counter_ << std::endl;
     activeConnections.erase(peer->getID());
   }
 


### PR DESCRIPTION
Building on PR #834 , this PR adds a per-connection identifier that makes it easier to keep track of which client is connecting, and reference their request.

Use case: Long-running queries can be assigned an ID, rather than using the peer FD (reused), which helps with debugging and provides an easier accounting method when cleaning up a long-running query's client disconnect before a full response has been generated.