### PR TITLE
Code simplification in RequestParser usage

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -416,9 +416,9 @@ public:
   ResponseWriter clone() const;
 
   std::shared_ptr<Tcp::Peer> getPeer() const {
-      if (auto sp = peer_.lock())
-          return sp;
-      return nullptr;
+    if (auto sp = peer_.lock())
+      return sp;
+    return nullptr;
   }
 
 private:

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -589,7 +589,6 @@ private:
   void onConnection(const std::shared_ptr<Tcp::Peer> &peer) override;
   void onInput(const char *buffer, size_t len,
                const std::shared_ptr<Tcp::Peer> &peer) override;
-  RequestParser &getParser(const std::shared_ptr<Tcp::Peer> &peer) const;
 
 private:
   size_t maxRequestSize_ = Const::DefaultMaxRequestSize;

--- a/include/pistache/peer.h
+++ b/include/pistache/peer.h
@@ -9,7 +9,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <unordered_map>
 
 #include <pistache/async.h>
 #include <pistache/http.h>
@@ -43,9 +42,8 @@ public:
 
   void *ssl() const;
 
-  void putData(std::string name, std::shared_ptr<Http::Parser> data);
-  std::shared_ptr<Http::Parser> getData(std::string name) const;
-  std::shared_ptr<Http::Parser> tryGetData(std::string name) const;
+  void setParser(std::shared_ptr<Http::RequestParser> parser);
+  std::shared_ptr<Http::RequestParser> getParser() const;
 
   Async::Promise<ssize_t> send(const RawBuffer &buffer, int flags = 0);
   size_t getID() const;
@@ -62,7 +60,7 @@ private:
   Address addr;
 
   std::string hostname_;
-  std::unordered_map<std::string, std::shared_ptr<Http::Parser>> data_;
+  std::shared_ptr<Http::RequestParser> parser_;
 
   void *ssl_ = nullptr;
   const size_t id_;

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -423,12 +423,12 @@ BodyStep::Chunk::Result BodyStep::Chunk::parse(StreamCursor &cursor) {
   if (available + alreadyAppendedChunkBytes < size + 2) {
     cursor.advance(available);
     message->body_.append(chunkData.rawText(), available);
-    alreadyAppendedChunkBytes +=available;
+    alreadyAppendedChunkBytes += available;
     return Incomplete;
   }
   cursor.advance(size - alreadyAppendedChunkBytes);
-  
-  //trailing EOL
+
+  // trailing EOL
   cursor.advance(2);
 
   message->body_.append(chunkData.rawText(), size - alreadyAppendedChunkBytes);
@@ -798,8 +798,10 @@ Async::Promise<ssize_t> ResponseWriter::putOnWire(const char *data,
         .then<std::function<Async::Promise<ssize_t>(ssize_t)>,
               std::function<void(std::exception_ptr &)>>(
             [=](int /*l*/) {
-              return Async::Promise<ssize_t>([=](
-                  Async::Deferred<ssize_t> /*deferred*/) mutable { return; });
+              return Async::Promise<ssize_t>(
+                  [=](Async::Deferred<ssize_t> /*deferred*/) mutable {
+                    return;
+                  });
             },
 
             [=](std::exception_ptr &eptr) {
@@ -922,7 +924,7 @@ void Handler::onInput(const char *buffer, size_t len,
     }
 
     auto state = parser->parse();
-    auto& request = parser->request;
+    auto &request = parser->request;
 
     if (state == Private::State::Done) {
       ResponseWriter response(transport(), request, this, peer);

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -111,8 +111,6 @@ const HttpMethods httpMethods = {
 
 } // namespace
 
-static constexpr const char *ParserData = "__Parser";
-
 namespace Private {
 
 Step::Step(Message *request) : message(request) {}
@@ -915,16 +913,16 @@ Private::ParserImpl<Http::Response>::ParserImpl(size_t maxDataSize)
 
 void Handler::onInput(const char *buffer, size_t len,
                       const std::shared_ptr<Tcp::Peer> &peer) {
-  auto &parser = getParser(peer);
+  auto parser = peer->getParser();
   try {
-    if (!parser.feed(buffer, len)) {
-      parser.reset();
+    if (!parser->feed(buffer, len)) {
+      parser->reset();
       throw HttpError(Code::Request_Entity_Too_Large,
                       "Request exceeded maximum buffer size");
     }
 
-    auto state = parser.parse();
-    auto& request = parser.request;
+    auto state = parser->parse();
+    auto& request = parser->request;
 
     if (state == Private::State::Done) {
       ResponseWriter response(transport(), request, this, peer);
@@ -944,24 +942,24 @@ void Handler::onInput(const char *buffer, size_t len,
       }
 
       onRequest(request, std::move(response));
-      parser.reset();
+      parser->reset();
     }
 
   } catch (const HttpError &err) {
-    ResponseWriter response(transport(), parser.request, this, peer);
+    ResponseWriter response(transport(), parser->request, this, peer);
     response.send(static_cast<Code>(err.code()), err.reason());
-    parser.reset();
+    parser->reset();
   }
 
   catch (const std::exception &e) {
-    ResponseWriter response(transport(), parser.request, this, peer);
+    ResponseWriter response(transport(), parser->request, this, peer);
     response.send(Code::Internal_Server_Error, e.what());
-    parser.reset();
+    parser->reset();
   }
 }
 
 void Handler::onConnection(const std::shared_ptr<Tcp::Peer> &peer) {
-  peer->putData(ParserData, std::make_shared<RequestParser>(maxRequestSize_));
+  peer->setParser(std::make_shared<RequestParser>(maxRequestSize_));
 }
 
 void Handler::onTimeout(const Request & /*request*/,
@@ -999,11 +997,6 @@ size_t Handler::getMaxRequestSize() const { return maxRequestSize_; }
 void Handler::setMaxResponseSize(size_t value) { maxResponseSize_ = value; }
 
 size_t Handler::getMaxResponseSize() const { return maxResponseSize_; }
-
-RequestParser &
-Handler::getParser(const std::shared_ptr<Tcp::Peer> &peer) const {
-  return static_cast<RequestParser &>(*peer->getData(ParserData));
-}
 
 } // namespace Http
 } // namespace Pistache

--- a/src/common/peer.cc
+++ b/src/common/peer.cc
@@ -78,30 +78,12 @@ int Peer::fd() const {
   return fd_;
 }
 
-void Peer::putData(std::string name, std::shared_ptr<Http::Parser> data) {
-  auto it = data_.find(name);
-  if (it != std::end(data_)) {
-    throw std::runtime_error("The data already exists");
-  }
-
-  data_.insert(std::make_pair(std::move(name), std::move(data)));
+void Peer::setParser(std::shared_ptr<Http::RequestParser> parser) {
+  parser_ = parser;
 }
 
-std::shared_ptr<Http::Parser> Peer::getData(std::string name) const {
-  auto data = tryGetData(std::move(name));
-  if (data == nullptr) {
-    throw std::runtime_error("The data does not exist");
-  }
-
-  return data;
-}
-
-std::shared_ptr<Http::Parser> Peer::tryGetData(std::string(name)) const {
-  auto it = data_.find(name);
-  if (it == std::end(data_))
-    return nullptr;
-
-  return it->second;
+std::shared_ptr<Http::RequestParser> Peer::getParser() const {
+  return parser_;
 }
 
 Async::Promise<ssize_t> Peer::send(const RawBuffer &buffer, int flags) {

--- a/src/common/peer.cc
+++ b/src/common/peer.cc
@@ -82,9 +82,7 @@ void Peer::setParser(std::shared_ptr<Http::RequestParser> parser) {
   parser_ = parser;
 }
 
-std::shared_ptr<Http::RequestParser> Peer::getParser() const {
-  return parser_;
-}
+std::shared_ptr<Http::RequestParser> Peer::getParser() const { return parser_; }
 
 Async::Promise<ssize_t> Peer::send(const RawBuffer &buffer, int flags) {
   return transport()->asyncWrite(fd_, buffer, flags);


### PR DESCRIPTION
I have found that `Peer::getData`, `Peer::tryGetData` and `putData` are used only in one scenario (`Handler::onInput`) and decided that it's not needed to keep one key `__Parser` with `Http::Parser>` in std::unordered_map. Based on `Peer::putData` method logic only one parser can be inserted. Am I right?