### PR TITLE
Forbid access to request parser object for clients

### DIFF
--- a/include/pistache/peer.h
+++ b/include/pistache/peer.h
@@ -30,6 +30,7 @@ class Transport;
 class Peer {
 public:
   friend class Transport;
+  friend class Http::Handler;
 
   ~Peer();
 
@@ -42,9 +43,6 @@ public:
 
   void *ssl() const;
 
-  void setParser(std::shared_ptr<Http::RequestParser> parser);
-  std::shared_ptr<Http::RequestParser> getParser() const;
-
   Async::Promise<ssize_t> send(const RawBuffer &buffer, int flags = 0);
   size_t getID() const;
 
@@ -52,6 +50,9 @@ protected:
   Peer(Fd fd, const Address &addr, void *ssl);
 
 private:
+  void setParser(std::shared_ptr<Http::RequestParser> parser);
+  std::shared_ptr<Http::RequestParser> getParser() const;
+
   void associateTransport(Transport *transport);
   Transport *transport() const;
 


### PR DESCRIPTION
Now, I am thinking how to fix #798 issue and found that from client side `RequestParser` can be accessed, like:
```
void handleReady(const Rest::Request&, Http::ResponseWriter response)
{
    cout << "Ready" << endl;
    auto peer = response.peer();
    if (peer)
    {
        auto parser = peer->getParser();
       ...
    }
    response.send(Http::Code::Ok); //, "1");
}
```
From my point of view it's bad, clients shouldn't have an access to internal details of handling http request.

I'm not sure that I'm proposing the best solution for this problem, but I think it's better than the current situation.