### PR TITLE
Delete unused code and clang-format

### DIFF
--- a/include/pistache/os.h
+++ b/include/pistache/os.h
@@ -86,7 +86,6 @@ struct Event {
   explicit Event(Tag _tag);
 
   Flags<NotifyOn> flags;
-  Fd fd;
   Tag tag;
 };
 

--- a/include/pistache/reactor.h
+++ b/include/pistache/reactor.h
@@ -43,7 +43,6 @@ public:
     bool isWritable() const { return flags.hasFlag(Polling::NotifyOn::Write); }
     bool isHangup() const { return flags.hasFlag(Polling::NotifyOn::Hangup); }
 
-    Fd getFd() const { return this->fd; }
     Polling::Tag getTag() const { return this->tag; }
   };
 
@@ -120,7 +119,7 @@ public:
   void modifyFd(const Key &key, Fd fd, Polling::NotifyOn interest,
                 Polling::Tag tag, Polling::Mode mode = Polling::Mode::Level);
 
-  void removeFd(const Key& key, Fd fd);
+  void removeFd(const Key &key, Fd fd);
 
   void runOnce();
   void run();

--- a/src/common/os.cc
+++ b/src/common/os.cc
@@ -118,7 +118,7 @@ cpu_set_t CpuSet::toPosix() const {
 
 namespace Polling {
 
-Event::Event(Tag _tag) : flags(), fd(-1), tag(_tag) {}
+Event::Event(Tag _tag) : flags(), tag(_tag) {}
 
 Epoll::Epoll()
     : epoll_fd([&]() { return TRY_RET(epoll_create(Const::MaxEvents)); }()) {}
@@ -171,7 +171,8 @@ int Epoll::poll(std::vector<Event> &events,
 
   int ready_fds = -1;
   do {
-    ready_fds = ::epoll_wait(epoll_fd, evs, Const::MaxEvents, static_cast<int>(timeout.count()));
+    ready_fds = ::epoll_wait(epoll_fd, evs, Const::MaxEvents,
+                             static_cast<int>(timeout.count()));
   } while (ready_fds < 0 && errno == EINTR);
 
   for (int i = 0; i < ready_fds; ++i) {


### PR DESCRIPTION
The field `Fd fd;` of `Event` class is not used in code. The `fd` value is obtained from `tag` field. 