### PR TITLE
Fix issue #798 - Part 1: partially decrease allocated memory during file upload

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -255,7 +255,7 @@ public:
 private:
   Timeout(const Timeout &other) = default;
 
-  Timeout(Tcp::Transport *transport_, Handler *handler_, Request request_,
+  Timeout(Tcp::Transport *transport_, Handler *handler_,
           std::weak_ptr<Tcp::Peer> peer_);
 
   void onTimeout(uint64_t numWakeup);
@@ -422,8 +422,8 @@ public:
   }
 
 private:
-  ResponseWriter(Tcp::Transport *transport, Request request, Handler *handler,
-                 std::weak_ptr<Tcp::Peer> peer);
+  ResponseWriter(Http::Version version, Tcp::Transport *transport,
+                 Handler *handler, std::weak_ptr<Tcp::Peer> peer);
 
   ResponseWriter(const ResponseWriter &other);
 
@@ -436,9 +436,9 @@ private:
   Response response_;
   std::weak_ptr<Tcp::Peer> peer_;
   DynamicStreamBuf buf_;
-  Tcp::Transport *transport_;
+  Tcp::Transport *transport_ = nullptr;
   Timeout timeout_;
-  ssize_t sent_bytes_;
+  ssize_t sent_bytes_ = 0;
 };
 
 Async::Promise<ssize_t>

--- a/include/pistache/peer.h
+++ b/include/pistache/peer.h
@@ -31,6 +31,7 @@ class Peer {
 public:
   friend class Transport;
   friend class Http::Handler;
+  friend class Http::Timeout;
 
   ~Peer();
 
@@ -52,6 +53,8 @@ protected:
 private:
   void setParser(std::shared_ptr<Http::RequestParser> parser);
   std::shared_ptr<Http::RequestParser> getParser() const;
+
+  Http::Request &request();
 
   void associateTransport(Transport *transport);
   Transport *transport() const;

--- a/src/common/peer.cc
+++ b/src/common/peer.cc
@@ -84,6 +84,14 @@ void Peer::setParser(std::shared_ptr<Http::RequestParser> parser) {
 
 std::shared_ptr<Http::RequestParser> Peer::getParser() const { return parser_; }
 
+Http::Request &Peer::request() {
+  if (!parser_) {
+    throw std::runtime_error("The peer has no associated parser");
+  }
+
+  return parser_->request;
+}
+
 Async::Promise<ssize_t> Peer::send(const RawBuffer &buffer, int flags) {
   return transport()->asyncWrite(fd_, buffer, flags);
 }


### PR DESCRIPTION
In this PR I'm trying to get rid of unnessessary `Request` object copying to `ResponseWriter` and `Timeout` objects.

In my test cases (upload 4 different files with 5Mb):
before:
```
==39205== HEAP SUMMARY:
==39205==     in use at exit: 10,600 bytes in 75 blocks
==39205==   total heap usage: 10,538 allocs, 10,463 frees, 167,452,849 bytes allocated
```

after my changes:
```
==41875== HEAP SUMMARY:
==41875==     in use at exit: 10,600 bytes in 75 blocks
==41875==   total heap usage: 10,412 allocs, 10,337 frees, 127,442,493 bytes allocated
```