### PR TITLE
Fix issue #798 - Part 2: Add getting request body by const reference

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -83,7 +83,8 @@ public:
   Version version() const;
   Code code() const;
 
-  std::string body() const;
+  const std::string &body() const;
+  std::string body();
 
   const CookieJar &cookies() const;
   CookieJar &cookies();

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -537,7 +537,9 @@ Version Message::version() const { return version_; }
 
 Code Message::code() const { return code_; }
 
-std::string Message::body() const { return body_; }
+const std::string &Message::body() const { return body_; }
+
+std::string Message::body() { return body_; }
 
 const Header::Collection &Message::headers() const { return headers_; }
 


### PR DESCRIPTION
I think it would better to add getting request body by const reference.

In my test cases (upload 4 different files with 5Mb):
before:
```
==41875== HEAP SUMMARY:
==41875==     in use at exit: 10,600 bytes in 75 blocks
==41875==   total heap usage: 10,412 allocs, 10,337 frees, 127,442,493 bytes allocated
```

after my changes:
```
==50087== HEAP SUMMARY:
==50087==     in use at exit: 10,600 bytes in 75 blocks
==50087==   total heap usage: 10,410 allocs, 10,335 frees, 107,442,525 bytes allocated
```