### PR TITLE
Rest::Router add client disconnect handlers

### DIFF
--- a/include/pistache/router.h
+++ b/include/pistache/router.h
@@ -67,7 +67,8 @@ struct Route {
 
   typedef std::function<bool(Http::Request& req, Http::ResponseWriter& resp)> Middleware;
 
-  typedef std::function<void(const std::shared_ptr<Tcp::Peer> &peer)> DisconnectHandler;
+  typedef std::function<void(const std::shared_ptr<Tcp::Peer> &peer)>
+      DisconnectHandler;
 
   explicit Route(Route::Handler handler) : handler_(std::move(handler)) {}
 

--- a/include/pistache/router.h
+++ b/include/pistache/router.h
@@ -67,7 +67,7 @@ struct Route {
 
   typedef std::function<bool(Http::Request& req, Http::ResponseWriter& resp)> Middleware;
 
-  typedef std::function<bool(const std::shared_ptr<Tcp::Peer> &peer)> DisconnectHandler;
+  typedef std::function<void(const std::shared_ptr<Tcp::Peer> &peer)> DisconnectHandler;
 
   explicit Route(Route::Handler handler) : handler_(std::move(handler)) {}
 

--- a/src/server/router.cc
+++ b/src/server/router.cc
@@ -489,7 +489,7 @@ void Router::addRoute(Http::Method method, const std::string &resource,
 }
 
 void Router::disconnectPeer(const std::shared_ptr<Tcp::Peer> &peer) {
-  for (const auto & handler : disconnectHandlers) {
+  for (const auto &handler : disconnectHandlers) {
     handler(peer);
   }
 }

--- a/src/server/router.cc
+++ b/src/server/router.cc
@@ -306,8 +306,7 @@ void RouterHandler::onRequest(const Http::Request &req,
   router->route(req, std::move(response));
 }
 
-void RouterHandler::onDisconnection(const std::shared_ptr<Tcp::Peer> &peer)
-{
+void RouterHandler::onDisconnection(const std::shared_ptr<Tcp::Peer> &peer) {
   router->disconnectPeer(peer);
 }
 
@@ -490,9 +489,9 @@ void Router::addRoute(Http::Method method, const std::string &resource,
 }
 
 void Router::disconnectPeer(const std::shared_ptr<Tcp::Peer> &peer) {
-    for (const auto & handler : disconnectHandlers) {
-        handler(peer);
-    }
+  for (const auto & handler : disconnectHandlers) {
+    handler(peer);
+  }
 }
 
 namespace Routes {

--- a/tests/router_test.cc
+++ b/tests/router_test.cc
@@ -415,16 +415,16 @@ TEST(router_test, test_client_disconnects) {
   Rest::Router router;
 
   Routes::Head(router, "/moogle",
-      [&count_found](const Pistache::Rest::Request &,
-        Pistache::Http::ResponseWriter response) {
-      count_found++;
-      response.send(Pistache::Http::Code::Ok);
-      return Pistache::Rest::Route::Result::Ok;
-      });
+               [&count_found](const Pistache::Rest::Request &,
+                              Pistache::Http::ResponseWriter response) {
+                 count_found++;
+                 response.send(Pistache::Http::Code::Ok);
+                 return Pistache::Rest::Route::Result::Ok;
+               });
 
   router.addDisconnectHandler(
-      [&count_disconnect] (const std::shared_ptr<Tcp::Peer> &) {
-      count_disconnect.increment();
+      [&count_disconnect](const std::shared_ptr<Tcp::Peer> &) {
+        count_disconnect.increment();
       });
 
   endpoint->setHandler(router.handler());
@@ -442,6 +442,4 @@ TEST(router_test, test_client_disconnects) {
   endpoint->shutdown();
   ASSERT_EQ(result, 1);
 }
-}
-
-
+} // namespace


### PR DESCRIPTION
- This exposes a mechanism for Rest::Router users to add handlers on client disconnection.
- Builds on prior work to expose `onDisconnection()` on `Http::Handler` (Rest::Router handler is in a Private namespace and isn't easily inheritable).
- Added unit test (the WaitHelper code is pretty cool, thanks @hyperxor )