### PR TITLE
listener: add CloseOnExec option

### DIFF
--- a/include/pistache/tcp.h
+++ b/include/pistache/tcp.h
@@ -27,6 +27,7 @@ enum class Options : uint64_t {
   QuickAck = FastOpen << 1,
   ReuseAddr = QuickAck << 1,
   ReusePort = ReuseAddr << 1,
+  CloseOnExec = ReusePort << 1,
 };
 
 DECLARE_FLAGS_OPERATORS(Options)

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -221,7 +221,11 @@ void Listener::bind(const Address &address) {
 
   const addrinfo *addr = nullptr;
   for (addr = addr_info.get_info_ptr(); addr; addr = addr->ai_next) {
-    fd = ::socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+    auto socktype = addr->ai_socktype;
+    if (options_.hasFlag(Options::CloseOnExec))
+      socktype |= SOCK_CLOEXEC;
+
+    fd = ::socket(addr->ai_family, socktype, addr->ai_protocol);
     if (fd < 0)
       continue;
 


### PR DESCRIPTION
This solves following situation:
- we have a server using a Pistache, using port 9080
  - one of endpoints uses fork() or some similar stuff to create a child process which runs in background (and can outlive its parent)
- endpoint gets called, child process is created
- server gets killed
- child lives on, blocking port 9080
- server cannot be restarted, because port 9080 is in use

example:
```
#include <cstdlib>

#include "pistache/endpoint.h"

using namespace Pistache;

class HelloHandler : public Http::Handler {
public:
    HTTP_PROTOTYPE(HelloHandler)

    void onRequest(const Http::Request&, Http::ResponseWriter response) override
    {
        std::system("sleep 1000 <&- &"); // fork magic - fire and forget style
        response.send(Http::Code::Ok, "success");
    }
};

int main()
{
    Pistache::Address addr(Pistache::Ipv4::any(), Pistache::Port(9080));
    auto opts = Pistache::Http::Endpoint::options().threads(1);
    // opts.flags(Pistache::Tcp::Options::CloseOnExec); // we can uncomment this to fix this behavior

    Http::Endpoint server(addr);
    server.init(opts);
    server.setHandler(Http::make_handler<HelloHandler>());
    server.serve();
}
```

```
$ cmake ..
...
$ make
...
$ ./cloexec
```

other terminal
```
$ curl 127.0.0.1:9080
success
$ sudo netstat -lepunt | grep 9080 
tcp        0      0 0.0.0.0:9080            0.0.0.0:*               LISTEN      1000       711080     98094/./cloexec
$ pkill -9 cloxec
$ sudo netstat -lepunt | grep 9080 #this would return nothing if we used CloseOnExec
tcp        0      0 0.0.0.0:9080            0.0.0.0:*               LISTEN      1000       711080     98359/sleep
```
