### PR TITLE
Modernize CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.4)
+cmake_minimum_required (VERSION 3.9)
 
 set(CMAKE_BUILD_TYPE_INIT Release)
 
@@ -13,13 +13,13 @@ project (pistache
 
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wconversion -pedantic -Wextra -Wno-missing-field-initializers")
+add_compile_options(-Wall -Wconversion -pedantic -Wextra -Wno-missing-field-initializers)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
 
 include(CheckAtomic)
 
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -g -O0 -ftest-coverage -fstack-protector-all --param=ssp-buffer-size=4")
+    add_compile_options(-g -Og -ftest-coverage -fstack-protector-all --param=ssp-buffer-size=4)
 endif()
 
 option(BUILD_SHARED_LIBS "build shared library" ON)
@@ -31,8 +31,12 @@ option(PISTACHE_INSTALL "add pistache as install target (recommended)" ON)
 option(PISTACHE_USE_SSL "add support for SSL server" OFF)
 
 # require fat LTO objects in static library
-if(CMAKE_CXX_FLAGS MATCHES "-flto")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffat-lto-objects")
+if(CMAKE_INTERPROCEDURAL_OPTIMIZATION OR CMAKE_CXX_FLAGS MATCHES "-flto" OR CMAKE_CXX_FLAGS MATCHES "-flto=thin")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        add_compile_options(-ffat-lto-objects)
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        add_compile_options(-flto=full)
+    endif()
 endif()
 
 if (PISTACHE_BUILD_TESTS)
@@ -226,4 +230,3 @@ endif()
     #  dist target to the generated makefile...
     include(CPack)
     add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-pistache (0.0.002-pistache1) focal; urgency=medium
+pistache (0.0.002-pistache1) groovy; urgency=medium
 
   * Latest upstream.
 
- -- Kip Warner <kip@thevertigo.com>  Sun, 02 Aug 2020 18:26:47 -0700
+ -- Kip Warner <kip@thevertigo.com>  Sun, 27 Dec 2020 16:40:00 -0700
 


### PR DESCRIPTION
WIth this I'm trying to fix some of the issues pointed out in #827.

Changes:

Use `add_compile_options()` instead of modifying `CMAKE_CXX_FLAGS`.

Use `-Og` instead of `-O0` (from [gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html):
_"[-Og] is a better choice than -O0 for producing debuggable code because
some compiler passes that collect debug information are disabled at -O0"_)

Fix LTO check (previously it would fail because it checked only `CMAKE_CXX_FLAGS`. This didn't work when properly enabling LTO through `CMAKE_INTERPROCEDURAL_OPTIMIZATION`).
I'm not sure if I modified it correctly since I don't really understand
what that check is trying to do in the first place.

Check for Clang or GCC when applying compiler specific flags.

This changes require CMake 3.9 or higher, but I don't think this will
cause any issues.