### PR TITLE
Make fPIC optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option(PISTACHE_BUILD_EXAMPLES "build examples alongside the project" OFF)
 option(PISTACHE_BUILD_DOCS "build docs alongside the project" OFF)
 option(PISTACHE_INSTALL "add pistache as install target (recommended)" ON)
 option(PISTACHE_USE_SSL "add support for SSL server" OFF)
+option(PISTACHE_PIC "Enable pistache PIC" ON)
 
 # require fat LTO objects in static library
 if(CMAKE_INTERPROCEDURAL_OPTIMIZATION OR CMAKE_CXX_FLAGS MATCHES "-flto" OR CMAKE_CXX_FLAGS MATCHES "-flto=thin")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ set(SOURCE_FILES
 )
 
 add_library(pistache OBJECT ${SOURCE_FILES})
-set_target_properties(pistache PROPERTIES POSITION_INDEPENDENT_CODE $<BOOL:${PISTACHE_PIC}>)
+set_target_properties(pistache PROPERTIES POSITION_INDEPENDENT_CODE ${PISTACHE_PIC})
 add_definitions(-DONLY_C_LOCALE=1)
 
 set(PISTACHE_INCLUDE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ set(SOURCE_FILES
 )
 
 add_library(pistache OBJECT ${SOURCE_FILES})
-set_target_properties(pistache PROPERTIES POSITION_INDEPENDENT_CODE 1)
+set_target_properties(pistache PROPERTIES POSITION_INDEPENDENT_CODE $<BOOL:${PISTACHE_PIC}>)
 add_definitions(-DONLY_C_LOCALE=1)
 
 set(PISTACHE_INCLUDE
@@ -56,7 +56,7 @@ if (BUILD_SHARED_LIBS)
     )
 endif ()
 
-set_target_properties(pistache_static PROPERTIES 
+set_target_properties(pistache_static PROPERTIES
     OUTPUT_NAME ${Pistache_OUTPUT_NAME}
 )
 


### PR DESCRIPTION
For static library propose, fPIC is not mandatory, however, the current behavior is forcing it.

This PR brings fPIC as optional, but keeps it activated by default.