### PR TITLE
Fix #863 issues

### DIFF
--- a/.github/workflows/pistache.io.yaml
+++ b/.github/workflows/pistache.io.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build-and-deploy:
+  pistache.io-deploy:
     runs-on: ubuntu-20.04
 
     steps:
@@ -15,9 +15,9 @@ jobs:
       
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install yarnpkg npm --no-install-recommends --assume-yes -qq
-          sudo update-alternatives --install /usr/bin/yarn yarn /usr/bin/yarnpkg 10
-          sudo npm install --global --silent npx
+          sudo apt-get update && sudo apt-get install -qq npm --no-install-recommends --assume-yes
+          sudo npm install --global --silent yarn
+          sudo npm install --global --force --silent npx
       
       - name: Build docs site
         run: |
@@ -29,5 +29,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          publish_dir: ./pistache.io/build
           cname: pistache.io

--- a/pistache.io/docs/headers.md
+++ b/pistache.io/docs/headers.md
@@ -48,12 +48,6 @@ void parse(const std::string& data);
 
 This function is used to parse the header from the string representation. Alternatively, to avoid allocating memory for the string representation, a _raw_ version can be used:
 
-:::note Note to the Pistache team
-
-Why not to use a `std::string_view` instead?
-
-:::
-
 ```cpp
 void parseRaw(const char* str, size_t len);
 ```

--- a/pistache.io/docusaurus.config.js
+++ b/pistache.io/docusaurus.config.js
@@ -63,10 +63,6 @@ module.exports = {
           title: 'More',
           items: [
             {
-              label: 'Blog',
-              to: 'blog',
-            },
-            {
               label: 'GitHub',
               href: 'https://github.com/pistacheio/pistache',
             },

--- a/pistache.io/static/CNAME
+++ b/pistache.io/static/CNAME
@@ -1,1 +1,0 @@
-pistache.io


### PR DESCRIPTION
This PR should fix the GitHub Action (installing yarn via npm and fixing the directory that the action would push to the `gh-pages` branch), as well as one dead link pointing to a nonexistent blog section and a note about `std::string_view` that really shouldn't be published with the documentation.

I tested everything on a clone of the repo, and everything seems to work ([pistache.pappacoda.it](https://pistache.pappacoda.it) is on and fine)