### PR TITLE
Only trigger pistache.io deploy when needed

### DIFF
--- a/.github/workflows/pistache.io.yaml
+++ b/.github/workflows/pistache.io.yaml
@@ -3,8 +3,7 @@ name: pistache.io
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    paths: pistache.io/**
 
 jobs:
   pistacheio-deploy:


### PR DESCRIPTION
The workflow was triggered every time someone would make a PR, resulting in a failure due to missing privileges of the user. 
It was also triggered when unrelated files were modified.
This PR fixes that.