### PR TITLE
Swagger: Adding Query parameter to route description.

### DIFF
--- a/include/pistache/thirdparty/serializer/rapidjson.h
+++ b/include/pistache/thirdparty/serializer/rapidjson.h
@@ -62,13 +62,18 @@ void serializePC(Writer &writer, const Schema::ProduceConsume &pc) {
 
 template <typename Writer>
 void serializeParameter(Writer &writer, const Schema::Parameter &parameter) {
+#define LOC(_, name) name,
+  static char* locations[] = {
+          PARAMETER_LOCATIONS
+  };
+#undef LOC
   writer.StartObject();
   {
     writer.String("name");
     writer.String(parameter.name.c_str());
     writer.String("in");
     // @Feature: support other types of parameters
-    writer.String("path");
+    writer.String(locations[parameter.location]);
     writer.String("description");
     writer.String(parameter.description.c_str());
     writer.String("required");

--- a/src/common/description.cc
+++ b/src/common/description.cc
@@ -184,9 +184,9 @@ SubPath SubPath::path(const std::string &prefix) {
   return SubPath(this->prefix + prefix, paths);
 }
 
-Parameter::Parameter(std::string name, std::string description)
-    : name(std::move(name)), description(std::move(description)),
-      required(true), type() {}
+Parameter::Parameter(std::string name, std::string description, Location location, bool required)
+    : name(std::move(name)), description(std::move(description)), location(location),
+      required(required), type() {}
 
 Response::Response(Http::Code statusCode, std::string description)
     : statusCode(statusCode), description(std::move(description)) {}


### PR DESCRIPTION
We handled this by using enums to extend the Parameter class, and a function to allow easy adding of query parameters.

We're not 100% sure if the query function should be on the subpath as well, though that should be easily enough removed if necessary.