### PR TITLE
Add basic authentication support for Swagger JSON

### DIFF
--- a/include/pistache/description.h
+++ b/include/pistache/description.h
@@ -143,6 +143,45 @@ private:
   Info *info_;
 };
 
+#define AUTHENTICATION_TYPES                                      \
+  AUTH_TYPE(ApiKey, "apiKey")
+
+enum class AuthenticationType {
+#define AUTH_TYPE(name, _) name,
+            AUTHENTICATION_TYPES
+#undef AUTH_TYPE
+};
+
+#define AUTHENTICATION_LOCATIONS                                      \
+  AUTH_LOC(Header, "header")                                          \
+  AUTH_LOC(Query, "query")
+
+enum class AuthenticationLocation {
+#define AUTH_LOC(name, _) name,
+            AUTHENTICATION_LOCATIONS
+#undef AUTH_LOC
+};
+
+struct Authentication {
+  Authentication(std::string title);
+
+  std::string title;
+  AuthenticationType type;
+  AuthenticationLocation location;
+  std::string name;
+};
+
+struct AuthenticationBuilder {
+  explicit AuthenticationBuilder(Authentication *auth);
+
+  AuthenticationBuilder &type(AuthenticationType type);
+  AuthenticationBuilder &location(AuthenticationLocation loc);
+  AuthenticationBuilder &name(std::string name);
+
+private:
+  Authentication *auth_;
+};
+
 struct DataType {
   virtual const char *typeName() const = 0;
   virtual const char *format() const = 0;
@@ -380,6 +419,7 @@ public:
               std::string description = "");
 
   Schema::InfoBuilder info();
+  Schema::AuthenticationBuilder authentication(std::string title);
 
   Description &host(std::string value);
   Description &basePath(std::string value);
@@ -423,6 +463,7 @@ public:
                                    std::string description);
 
   Schema::Info rawInfo() const { return info_; }
+  std::vector<Schema::Authentication> rawAuthenticationSchemas() const { return authenticationSchemes_; }
   std::string rawHost() const { return host_; }
   std::string rawBasePath() const { return basePath_; }
   std::vector<Scheme> rawSchemes() const { return schemes_; }
@@ -431,6 +472,7 @@ public:
 
 private:
   Schema::Info info_;
+  std::vector<Schema::Authentication> authenticationSchemes_;
   std::string host_;
   std::string basePath_;
   std::vector<Scheme> schemes_;

--- a/src/common/description.cc
+++ b/src/common/description.cc
@@ -213,6 +213,28 @@ InfoBuilder &InfoBuilder::license(std::string name, std::string url) {
   return *this;
 }
 
+Authentication::Authentication(std::string title) : title(std::move(title)) {}
+
+AuthenticationBuilder::AuthenticationBuilder(Authentication *auth) : auth_(auth) {}
+
+AuthenticationBuilder &AuthenticationBuilder::type(AuthenticationType type)
+{
+  auth_->type = type;
+  return *this;
+}
+
+AuthenticationBuilder &AuthenticationBuilder::location(AuthenticationLocation loc)
+{
+  auth_->location = loc;
+  return *this;
+}
+
+AuthenticationBuilder &AuthenticationBuilder::name(std::string name)
+{
+  auth_->name = std::move(name);
+  return *this;
+}
+
 } // namespace Schema
 
 Description::Description(std::string title, std::string version,
@@ -223,6 +245,12 @@ Description::Description(std::string title, std::string version,
 Schema::InfoBuilder Description::info() {
   Schema::InfoBuilder builder(&info_);
   return builder;
+}
+
+Schema::AuthenticationBuilder Description::authentication(std::string title)
+{
+  auto it = authenticationSchemes_.emplace(authenticationSchemes_.end(), std::move(title));
+  return Schema::AuthenticationBuilder(&*it);
 }
 
 Description &Description::host(std::string value) {


### PR DESCRIPTION
Multiple authentication schemas are supported, for both query and header locations.

Security is only applied to the root at this time.