### PR TITLE
Add Meson clang-format target

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -115,3 +115,10 @@ endif
 if get_option('PISTACHE_BUILD_DOCS')
 	subdir('docs')
 endif
+
+if find_program('clang-format', required: false).found()
+	run_target(
+		'format',
+		command: (find_program('tools/format.sh'))
+	)
+endif

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,6 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -eu
+
+if [ ! -z ${MESON_SOURCE_ROOT+x} ]; then cd "${MESON_SOURCE_ROOT}"; fi
 
 find_files() {
     git ls-files --cached --exclude-standard --others | grep -E '\.(cc|cpp|h)$'


### PR DESCRIPTION
Since Meson doesn't have a way of specifying the working directory of a command, I had to modify the script to make it cd into the source root when ran from Meson.

You can run the format target with `meson compile -C builddir format` or `ninja -C builddir format`.

Also, I changed the shell from bash to `/bin/sh`, since bash isn't really required and a generic POSIX shell would work just fine