### PR TITLE
Fix warning: backslash-newline at end of file

### DIFF
--- a/include/pistache/prototype.h
+++ b/include/pistache/prototype.h
@@ -28,4 +28,4 @@ public:                                          \
     std::shared_ptr<Base> clone() const override \
     {                                            \
         return std::make_shared<Class>(*this);   \
-    }\
+    }


### PR DESCRIPTION
I have [noticed](https://travis-ci.org/github/pistacheio/pistache/jobs/766565105#L3939) a warning message:
```
[104/169] Compiling C++ object tests/r...est_size_test.p/request_size_test.cc.o
In file included from ../include/pistache/tcp.h:14,
                 from ../include/pistache/http.h:29,
                 from ../include/pistache/client.h:10,
                 from ../tests/request_size_test.cc:2:
../include/pistache/prototype.h:26:50: warning: backslash-newline at end of file
 #define PROTOTYPE_OF(Base, Class)                \
```