### PR TITLE
Make Travis less verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -250,7 +250,7 @@ before_script:
   # Print debug system information
   - cat /proc/sys/kernel/core_pattern
   - cat /etc/default/apport || true
-  - systemctl list-units --type=service --state=running
+  - systemctl list-units --type=service --state=running || true
 
   # Meson debug build
   - meson setup meson_build_debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -250,8 +250,7 @@ before_script:
   # Print debug system information
   - cat /proc/sys/kernel/core_pattern
   - cat /etc/default/apport || true
-  - service --status-all || true
-  - initctl list || true
+  - systemctl list-units --type=service --state=running
 
   # Meson debug build
   - meson setup meson_build_debug
@@ -299,23 +298,23 @@ script:
   # Set the ulimit
   - ulimit -c unlimited -S
 
-  # CMake debug build
-  - cmake --build cmake_build_debug --parallel 2 --target all test -- ARGS='-V'
-
-  # CMake debug build, no SSL
-  - cmake --build cmake_build_debug-nossl --parallel 2 --target all test -- ARGS='-V'
-
-  # CMake release build
-  - cmake --build cmake_build_release --parallel 2 -- ARGS='-V'
-
   # Meson debug build
-  - meson compile -C meson_build_debug --jobs 2 && meson test -C meson_build_debug || (cat meson_build_debug/meson-logs/testlog.txt && false)
+  - meson compile -C meson_build_debug --jobs 2 && meson test -C meson_build_debug --print-errorlogs --no-stdsplit
 
   # Meson debug build, no SSL
-  - meson compile -C meson_build_debug_nossl --jobs 2 && meson test -C meson_build_debug_nossl || (cat meson_build_debug/meson-logs/testlog.txt && false)
+  - meson compile -C meson_build_debug_nossl --jobs 2 && meson test -C meson_build_debug_nossl --print-errorlogs --no-stdsplit
 
   # Meson release build
   - meson compile -C meson_build_release --jobs 2
+
+  # CMake debug build
+  - CTEST_OUTPUT_ON_FAILURE=True cmake --build cmake_build_debug --parallel 2 --target all test
+
+  # CMake debug build, no SSL
+  - CTEST_OUTPUT_ON_FAILURE=True cmake --build cmake_build_debug-nossl --parallel 2 --target all test
+
+  # CMake release build
+  - cmake --build cmake_build_release --parallel 2
 
 after_failure:
   - CRASHFILES=$(find /var/crash/ -mindepth 1 -maxdepth 1 -print)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ project (pistache
 
 include(GNUInstallDirs)
 
-add_compile_options(-Wall -Wconversion -pedantic -Wextra -Wno-missing-field-initializers)
+add_compile_options(-Wall -Wextra -Wpedantic -Wconversion -Wno-sign-conversion -Wno-missing-field-initializers)
 
 option(BUILD_SHARED_LIBS "build shared library" ON)
 option(PISTACHE_BUILD_TESTS "build tests alongside the project" OFF)


### PR DESCRIPTION
I find it very difficult to navigate Travis CI logs, since all the tests output gets printed. With this change `meson test` and `cmake --target test` will print test logs only when they fail, reducing eccessive noise.