### PR TITLE
Remove custom format target in Meson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -228,7 +228,7 @@ before_install:
   # Check source code formatting
   - if [ $TRAVIS_PULL_REQUEST != "false" ]; then changed_src=$(git diff --name-only master...HEAD | egrep "\.(h|cc)$" | grep -v "include/pistache/thirdparty" || [ $? == 1 ]); fi
   - if [ ! -z "$changed_src" ]; then git-clang-format-10 --quiet --binary $(which clang-format-10) --diff master HEAD -- $changed_src > ./clang-format-diff; fi
-  - if [ -s ./clang-format-diff ]; then cat ./clang-format-diff && echo "Format source code according to .clang-format rules. Make sure to run make format" && false; fi
+  - if [ -s ./clang-format-diff ]; then cat ./clang-format-diff && echo "Format source code according to .clang-format rules. Make sure to run ninja clang-format" && false; fi
 
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"

--- a/meson.build
+++ b/meson.build
@@ -64,10 +64,3 @@ endif
 if get_option('PISTACHE_BUILD_DOCS')
 	subdir('docs')
 endif
-
-if find_program('clang-format', required: false).found()
-	run_target(
-		'format',
-		command: (find_program('tools/format.sh'))
-	)
-endif

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -2,8 +2,6 @@
 
 set -eu
 
-if [ ! -z ${MESON_SOURCE_ROOT+x} ]; then cd "${MESON_SOURCE_ROOT}"; fi
-
 find_files() {
     git ls-files --cached --exclude-standard --others | grep -E '\.(cc|cpp|h)$'
 }


### PR DESCRIPTION
I've just found out that Meson automatically sets up a clang-format target when clang-format is found on the system, so there's no need to manually add that target.

It can be ran with `ninja clang-format`.

Details about this Meson feature can be found [here](https://mesonbuild.com/Code-formatting.html#clangformat)