### PR TITLE
Use GTest imported target in tests/CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,6 @@ if (PISTACHE_BUILD_TESTS)
             add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
         endif()
     endif()
-
-    enable_testing()
     add_subdirectory(tests)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,8 +5,13 @@ function(pistache_test test_name)
     set(TEST_SOURCE ${test_name}.cc)
 
     add_executable(${TEST_EXECUTABLE} ${TEST_SOURCE})
-    target_include_directories(${TEST_EXECUTABLE} PRIVATE ${GTEST_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS})
-    target_link_libraries(${TEST_EXECUTABLE} gtest gtest_main pistache_static ${CURL_LIBRARIES})
+    target_include_directories(${TEST_EXECUTABLE} PRIVATE ${CURL_INCLUDE_DIRS})
+    # CMake 3.20 and upstream GTest define GTest::gtest, older versions define GTest::GTest
+    if (TARGET GTest::gtest)
+        target_link_libraries(${TEST_EXECUTABLE} GTest::gtest GTest::gtest_main pistache_static ${CURL_LIBRARIES})
+    else ()
+        target_link_libraries(${TEST_EXECUTABLE} GTest::GTest GTest::Main pistache_static ${CURL_LIBRARIES})
+    endif ()
     add_test(${test_name} ${TEST_EXECUTABLE})
 endfunction()
 


### PR DESCRIPTION
Using imported targets instead of manually passing link and include flags is less error-prone and a good practice in general. Unfortunately different versions on CMake import targets with different names, so it is needed to check whether the new target name exists or not. This also ensures that all the correct flags are passed to compiler (previously `-pthread` wasn't passed to the tests, so linking errors could've happened. I think that everything worked fine because `pistache_static` provided the needed `Threads::Threads` dependency). 

I would've liked to also use the `CURL::libcurl` imported target, but it requires CMake 3.12 and would break CentOS 8 compatibility.

Edit: forgot to mention that I've also removed the `enable_testing()` call, since it is already done by `include(CTest)`

Edit 2: Travis build [here](https://travis-ci.org/github/pistacheio/pistache/builds/767446418)