### PR TITLE
Fix issue #842 and small refactoring

### DIFF
--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -548,7 +548,7 @@ namespace Pistache
             class BodyStep : public Step
             {
             public:
-                static constexpr auto Id = Meta::Hash::fnv1a("Headers");
+                static constexpr auto Id = Meta::Hash::fnv1a("Body");
 
                 explicit BodyStep(Message* message_)
                     : Step(message_)
@@ -611,7 +611,7 @@ namespace Pistache
 
                 virtual ~ParserBase() = default;
 
-                virtual bool feed(const char* data, size_t len);
+                bool feed(const char* data, size_t len);
                 virtual void reset();
                 State parse();
 
@@ -635,7 +635,6 @@ namespace Pistache
             public:
                 explicit ParserImpl(size_t maxDataSize);
 
-                bool feed(const char* data, size_t len) override;
                 void reset() override;
 
                 std::chrono::steady_clock::time_point time() const

--- a/include/pistache/http.h
+++ b/include/pistache/http.h
@@ -611,21 +611,15 @@ namespace Pistache
 
                 virtual ~ParserBase() = default;
 
-                bool feed(const char* data, size_t len);
+                virtual bool feed(const char* data, size_t len);
                 virtual void reset();
                 State parse();
 
                 Step* step();
-                std::chrono::steady_clock::time_point time() const
-                {
-                    return time_;
-                }
 
             protected:
                 std::array<std::unique_ptr<Step>, StepsCount> allSteps;
                 size_t currentStep = 0;
-
-                std::chrono::steady_clock::time_point time_;
 
             private:
                 ArrayStreamBuf<char> buffer;
@@ -641,9 +635,18 @@ namespace Pistache
             public:
                 explicit ParserImpl(size_t maxDataSize);
 
+                bool feed(const char* data, size_t len) override;
                 void reset() override;
 
+                std::chrono::steady_clock::time_point time() const
+                {
+                    return time_;
+                }
+
                 Request request;
+
+            private:
+                std::chrono::steady_clock::time_point time_;
             };
 
             template <>

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -1053,12 +1053,6 @@ namespace Pistache
             time_   = std::chrono::steady_clock::now();
         }
 
-        bool Private::ParserImpl<Http::Request>::feed(const char* data, size_t len)
-        {
-            time_ = std::chrono::steady_clock::now();
-            return ParserBase::feed(data, len);
-        }
-
         Private::ParserImpl<Http::Response>::ParserImpl(size_t maxDataSize)
             : ParserBase(maxDataSize)
             , response()

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -75,7 +75,6 @@ namespace Pistache
 
         void TransportImpl::onReady(const Aio::FdSet& fds)
         {
-            bool handled = false;
             for (const auto& entry : fds)
             {
                 if (entry.getTag() == Polling::Tag(timerFd))
@@ -83,12 +82,11 @@ namespace Pistache
                     uint64_t wakeups;
                     ::read(timerFd, &wakeups, sizeof wakeups);
                     checkIdlePeers();
-                    handled = true;
+                    break;
                 }
             }
 
-            if (!handled)
-                Base::onReady(fds);
+            Base::onReady(fds);
         }
 
         void TransportImpl::setHeaderTimeout(std::chrono::milliseconds timeout)
@@ -129,7 +127,7 @@ namespace Pistache
             for (const auto& idlePeer : idlePeers)
             {
                 ResponseWriter response(Http::Version::Http11, this, static_cast<Http::Handler*>(handler_.get()), idlePeer);
-                response.send(Http::Code::Request_Timeout).then([=](ssize_t) { removePeer(idlePeer); }, [=](std::exception_ptr) { removePeer(idlePeer); });
+                response.send(Http::Code::Request_Timeout).then([=](ssize_t) { std::cout << "Removing idle: " << idlePeer << "\n"; removePeer(idlePeer); }, [=](std::exception_ptr) { removePeer(idlePeer); });
             }
         }
 

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -127,7 +127,7 @@ namespace Pistache
             for (const auto& idlePeer : idlePeers)
             {
                 ResponseWriter response(Http::Version::Http11, this, static_cast<Http::Handler*>(handler_.get()), idlePeer);
-                response.send(Http::Code::Request_Timeout).then([=](ssize_t) { std::cout << "Removing idle: " << idlePeer << "\n"; removePeer(idlePeer); }, [=](std::exception_ptr) { removePeer(idlePeer); });
+                response.send(Http::Code::Request_Timeout).then([=](ssize_t) { removePeer(idlePeer); }, [=](std::exception_ptr) { removePeer(idlePeer); });
             }
         }
 

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -112,12 +112,12 @@ namespace Pistache
                 auto elapsed = now - time;
 
                 auto* step = parser->step();
-                if (step->id() == Private::RequestLineStep::Id)
+                if (step->id() == Private::RequestLineStep::Id || step->id() == Private::HeadersStep::Id)
                 {
                     if (elapsed > headerTimeout_ || elapsed > bodyTimeout_)
                         idlePeers.push_back(peer);
                 }
-                else if (step->id() == Private::HeadersStep::Id)
+                else if (step->id() == Private::BodyStep::Id)
                 {
                     if (elapsed > bodyTimeout_)
                         idlePeers.push_back(peer);

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -206,7 +206,7 @@ namespace Pistache
         void Endpoint::init(const Endpoint::Options& options)
         {
             listener.init(options.threads_, options.flags_, options.threadsName_);
-            listener.setTransportFactory([&] {
+            listener.setTransportFactory([this, options] {
                 if (!handler_)
                     throw std::runtime_error("Must call setHandler()");
 

--- a/tests/tcp_client.h
+++ b/tests/tcp_client.h
@@ -15,7 +15,7 @@ namespace Pistache
     do                                    \
     {                                     \
         auto ret = __VA_ARGS__;           \
-        if (ret < 0)                      \
+        if (ret == -1)                    \
         {                                 \
             lastError_ = strerror(errno); \
             lastErrno_ = errno;           \


### PR DESCRIPTION
Analyzing issue #842  I have found several serious (from my point of view) problems in Pistache code and I'm fixing them in this Pull Request.

1) The following code for removing idle peers does not work at all:
```
...
response.send(Http::Code::Request_Timeout).then([=](ssize_t) { removePeer(idlePeer); }, [=](std::exception_ptr) { removePeer(idlePeer); });
...
```
because `putOnWire` (`send` -> `sendImpl` -> `putOnWire`) returns `Async::Deferred`:
```
...
return Async::Promise<ssize_t>(
    [=](Async::Deferred<ssize_t> /*deferred*/) mutable {
        return;
    });
...
```

and as a result `removePeer` is not called.

2) Headers and body timeouts do not work appropriately. For instance, if you just execute connect to server on client side without sending any request data you will get:
```
HTTP/1.1 408 Request Timeout
Content-Length: 0
```
immediately because `time_` can be changed only in `feed` method call:
```
...
bool ParserBase::feed(const char* data, size_t len)
{
    time_ = std::chrono::steady_clock::now();
    return buffer.feed(data, len);
}
...
```

and as a result you get will timeout:
```
...
auto time        = parser->time();                <---------- 0, time_ is initialized with default contructor in ParserBase;

auto now     = std::chrono::steady_clock::now();
auto elapsed = now - time;

auto* step = parser->step();
if (step->id() == Private::RequestLineStep::Id)
{
    if (elapsed > headerTimeout_ || elapsed > bodyTimeout_)  <---------- timeout
        idlePeers.push_back(peer);
}
```
Also, from my point of view, it's dangerous to update `time_` on `feed` call. Client can send one byte at a time and as a result on each received byte we will update `time_` and exceed real timeout.

3) Wrong `Id` for `BodyStep` class.

4) There is a flaw in the following code:
```
...
void TransportImpl::onReady(const Aio::FdSet& fds)
{
    bool handled = false;
    for (const auto& entry : fds)
    {
        if (entry.getTag() == Polling::Tag(timerFd))
        {
            uint64_t wakeups;
            ::read(timerFd, &wakeups, sizeof wakeups);
            checkIdlePeers();
            handled = true;
        }
    }

    if (!handled)
        Base::onReady(fds);
}
...
```

When `onReady` is called with `fds` that contains descriptors with data (for reading) and `timerFd`, data will be missed without reading because `Base::onReady` is not called in this case. After my changes we cannot throw exception that fd is unknown:
```
void Transport::onReady(const Aio::FdSet& fds)
{
...
    else
    {
        throw std::runtime_error("Unknown fd");
    }
...
}
```

because `fd` can removed on `checkIdlePeers` call before `onReady` call.

5) There is a deadlock in the code when `toWriteLock` is locked in `asyncWriteImpl` method and the following statement:
```
...
deferred.resolve(static_cast<ssize_t>(totalWritten));
...
```
is executed that causes `removePeer` call with `Guard guard(toWriteLock)`. As a result this is the second 'lock' call on the same thread.

Refactoring:
1) Move setting and getting `time_` value from `ParseBase` to `ParserImpl<Http::Request>`, it's need only  on Request parser.
2) The following code:
```
void Transport::removePeer(const std::shared_ptr<Peer>& peer)
{
...
    {
        // Clean up buffers
        Guard guard(toWriteLock);
        auto& wq = toWrite[fd];
        while (wq.size() > 0)
        {
            wq.pop_front();
        }
        toWrite.erase(fd);
    }
...
}
```
that removing elements from `std::deque` is useless, because removing `fd` from `toWrite` will delete `std::deque`.

3) Small logging improvements in `http_server_test`.
4) Improve `bool send(const char* data, size_t len)` method and add getting raw `errno` value in `TcpClient` helper class.

Tests:
I have added and changed several tests that are related to headers and body timouts. Also it would be better to use `EXPECT...` over `ASSERT...` because in the case of raising ASSERT we do not have `server.shutdown();` call in the test case.

Please, review  my changes.
