### PR TITLE
fix endpoint initialization

### DIFF
--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -219,6 +219,11 @@ namespace Pistache
                 return transport;
             });
 
+            if(handler_) {
+                handler_->setMaxRequestSize(options.maxRequestSize_);
+                handler_->setMaxResponseSize(options.maxResponseSize_);
+            }
+
             options_ = options;
             logger_  = options.logger_;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ pistache_test(reactor_test)
 pistache_test(threadname_test)
 pistache_test(log_api_test)
 pistache_test(string_logger_test)
+pistache_test(endpoint_initialization_test)
 
 if (PISTACHE_USE_SSL)
 

--- a/tests/endpoint_initialization_test.cc
+++ b/tests/endpoint_initialization_test.cc
@@ -1,0 +1,48 @@
+#include <pistache/endpoint.h>
+#include <pistache/router.h>
+
+#include "gtest/gtest.h"
+
+using namespace Pistache;
+
+TEST(endpoint_initialization_test, initialize_options_before_handler) {
+    Rest::Router router;
+    auto handler = router.handler();
+    Address addr(Ipv4::any(), Port(0));
+    Http::Endpoint endpoint(addr);
+
+    size_t maxReqSize = 123;
+    size_t maxRespSize = 456;
+
+    auto opts = Http::Endpoint::options();
+    opts.threads(2);
+    opts.maxRequestSize(maxReqSize);
+    opts.maxResponseSize(maxRespSize);
+
+    endpoint.init(opts);
+    endpoint.setHandler(handler);
+
+    ASSERT_EQ(handler->getMaxRequestSize(), maxReqSize);
+    ASSERT_EQ(handler->getMaxResponseSize(), maxRespSize);
+}
+
+TEST(endpoint_initialization_test, initialize_handler_before_options) {
+    Rest::Router router;
+    auto handler = router.handler();
+    Address addr(Ipv4::any(), Port(0));
+    Http::Endpoint endpoint(addr);
+
+    size_t maxReqSize = 123;
+    size_t maxRespSize = 456;
+
+    auto opts = Http::Endpoint::options();
+    opts.threads(2);
+    opts.maxRequestSize(maxReqSize);
+    opts.maxResponseSize(maxRespSize);
+
+    endpoint.setHandler(handler);
+    endpoint.init(opts);
+
+    ASSERT_EQ(handler->getMaxRequestSize(), maxReqSize);
+    ASSERT_EQ(handler->getMaxResponseSize(), maxRespSize);
+}


### PR DESCRIPTION
fixes an issue where maxRequestSize and maxResponseSize are not correctly set in the handler instance if Endpoint.init is called after Endpoint.setHandler. In this case maxRequestSize and maxResponseSize were both set to their default values (4096 for maxRequestSize and Int32.max for maxResponseSize) even if the values configured in the options instance were set to other values.