### PR TITLE
Set up commit hook only if master project and make it "optional"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -107,4 +107,9 @@ if get_option('PISTACHE_BUILD_DOCS')
 	subdir('docs')
 endif
 
-run_command('git', 'config', '--local', 'core.hooksPath', '.hooks')
+if not meson.is_subproject()
+	git = find_program('git', required: false)
+	if git.found()
+		run_command(git, 'config', '--local', 'core.hooksPath', meson.source_root()/'.hooks')
+	endif
+endif


### PR DESCRIPTION
If someone is building Pistache from source as a subproject they are not going to commit any changes from there, and setting up the pre-commit hook is pointless. It is now also optional (that is, if git is not installed the hook won't be set, but it won't cause the build to fail), since git is not strictly needed to build the library, and if you don't have git installed you are probably not going to commit.

Tested with `autopkgtest` :)