### PR TITLE
listener: use sockaddr_storage for socket addrs

### DIFF
--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -107,7 +107,7 @@ namespace Pistache::Tcp
         TransportFactory defaultTransportFactory() const;
 
         void handleNewConnection();
-        int acceptConnection(struct sockaddr_in& peer_addr) const;
+        int acceptConnection(struct sockaddr_storage& peer_addr) const;
         void dispatchPeer(const std::shared_ptr<Peer>& peer);
 
         bool useSSL_            = false;


### PR DESCRIPTION
New connections can come from either IPv4 or IPv6 addresses. Hence, use
a sockaddress structure that can handle both.