### PR TITLE
Move copyright notices down the title in docs

### DIFF
--- a/pistache.io/docs/asynchronous-http-programming.md
+++ b/pistache.io/docs/asynchronous-http-programming.md
@@ -1,13 +1,13 @@
+---
+title: Asynchronous HTTP programming
+---
+
 <!--
 SPDX-FileCopyrightText: 2016 Mathieu Stefani
 SPDX-FileCopyrightText: 2021 Andrea Pappacoda
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-title: Asynchronous HTTP programming
----
 
 Interfaces provided by Pistaches are _asynchronous_ and _non-blocking_. Asynchronous programming allows for code to continue executing even if the result of a given call is not available yet. Calls that provide an asynchronous interface are referred to _asynchronous calls_.
 

--- a/pistache.io/docs/headers.md
+++ b/pistache.io/docs/headers.md
@@ -1,13 +1,13 @@
+---
+title: Headers
+---
+
 <!--
 SPDX-FileCopyrightText: 2016 Mathieu Stefani
 SPDX-FileCopyrightText: 2021 Andrea Pappacoda
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-title: Headers
----
 
 ## Overview
 

--- a/pistache.io/docs/http-handler.md
+++ b/pistache.io/docs/http-handler.md
@@ -1,14 +1,14 @@
+---
+id: http-handler
+title: HTTP handler
+---
+
 <!--
 SPDX-FileCopyrightText: 2016 Mathieu Stefani
 SPDX-FileCopyrightText: 2021 Andrea Pappacoda
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-id: http-handler
-title: HTTP handler
----
 
 Requests that are received by Pistache are handled by a special class called `Http::Handler`. This class declares a bunch of virtual methods that can be overriden to handle special events that occur on the socket and/or connection.
 

--- a/pistache.io/docs/quickstart.md
+++ b/pistache.io/docs/quickstart.md
@@ -1,14 +1,14 @@
+---
+title: Getting started
+slug: /
+---
+
 <!--
 SPDX-FileCopyrightText: 2016 Mathieu Stefani
 SPDX-FileCopyrightText: 2021 Andrea Pappacoda
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-title: Getting started
-slug: /
----
 
 Pistache is a web framework written in Modern C++ that focuses on performance and provides an elegant and asynchronous API.
 

--- a/pistache.io/docs/rest-description.md
+++ b/pistache.io/docs/rest-description.md
@@ -1,12 +1,12 @@
+---
+title: REST description
+---
+
 <!--
 SPDX-FileCopyrightText: 2016 Mathieu Stefani
 SPDX-FileCopyrightText: 2021 Andrea Pappacoda
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-title: REST description
----
 
 Documentation writing for this part is still in progress, please refer to the [rest_description](https://github.com/pistacheio/pistache/blob/master/examples/rest_description.cc) example.

--- a/pistache.io/docs/routing.md
+++ b/pistache.io/docs/routing.md
@@ -1,13 +1,13 @@
+---
+title: Routing
+---
+
 <!--
 SPDX-FileCopyrightText: 2016 Mathieu Stefani
 SPDX-FileCopyrightText: 2021 Andrea Pappacoda
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-title: Routing
----
 
 HTTP routing consists of binding an HTTP route to a C++ callback. A special component called an HTTP router will be in charge of dispatching HTTP requests to the right C++ callback. A route is composed of an HTTP verb associated to a resource:
 


### PR DESCRIPTION
Otherwise Docusaurus can't see the document's title, see https://github.com/pistacheio/pistache/actions/runs/974573916