### PR TITLE
Add autopkgtest GitHub Action

### DIFF
--- a/.github/workflows/autopkgtest.yaml
+++ b/.github/workflows/autopkgtest.yaml
@@ -1,0 +1,32 @@
+name: autopkgtest
+
+on:
+  [push, pull_request]
+
+defaults:
+  run:
+    shell: sh
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt -qq update
+        sudo apt -qq install autopkgtest genisoimage qemu-system vmdb2 meson cppcheck debhelper-compat dh-exec libc6-dev libcurl4-openssl-dev libgtest-dev libssl-dev libstdc++6 lintian pkg-config rapidjson-dev valgrind devscripts --no-install-recommends
+
+    - name: Build image
+      run: |
+        sudo autopkgtest-build-qemu --size 12G testing $HOME/autopkgtest-testing.img
+
+    - name: Build Debian package
+      run: |
+        ./debian/rules get-orig-source
+        debuild -S -sa -uc -us
+
+    - name: Run autopkgtest
+      run: autopkgtest ../pistache_*.dsc -- qemu --timeout-reboot=120 $HOME/autopkgtest-testing.img

--- a/.github/workflows/autopkgtest.yaml
+++ b/.github/workflows/autopkgtest.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Andrea Pappacoda <andrea@pappacoda.it>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: autopkgtest
 
 on:


### PR DESCRIPTION
This CI workflow builds and tests every commit and PR using autopkgtest. It builds a Debian Testing image using `autopkgtest-build-qemu` (`autopkgtest-buildvm-ubuntu-cloud` was too slow), builds the source package and test is with `autopkgtest`.

I'm trying to set this up for multiple architectures (see https://github.com/Tachi107/pistache/tree/actions-autopkgtest), but for whatever reason Ubuntu's `autopkgtest-build-qemu` is unable to build images for foreign architectures, as it fails with `"E: Unable to locate package linux-image-arm64"`, while it should be downloading it from https://packages.debian.org/testing/linux-image-arm64. This works fine on my Debian machine.

If you know how to help please let me know.