### PR TITLE
Cleanups

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2021 Andrea Pappacoda <andrea@pappacoda.it>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+subprojects/**

--- a/include/pistache/client.h
+++ b/include/pistache/client.h
@@ -132,7 +132,7 @@ namespace Pistache::Http
     public:
         ConnectionPool() = default;
 
-        void init(size_t maxConnsPerHost, size_t maxResponseSize);
+        void init(size_t maxConnectionsPerHost, size_t maxResponseSize);
 
         std::shared_ptr<Connection> pickConnection(const std::string& domain);
         static void releaseConnection(const std::shared_ptr<Connection>& connection);

--- a/include/pistache/serializer/rapidjson.h
+++ b/include/pistache/serializer/rapidjson.h
@@ -18,238 +18,232 @@
 #include <pistache/http_defs.h>
 #include <pistache/mime.h>
 
-namespace Pistache
+namespace Pistache::Rest::Serializer
 {
-    namespace Rest
+
+    template <typename Writer>
+    void serializeInfo(Writer& writer, const Schema::Info& info)
     {
-        namespace Serializer
+        writer.String("swagger");
+        writer.String("2.0");
+        writer.String("info");
+        writer.StartObject();
         {
-
-            template <typename Writer>
-            void serializeInfo(Writer& writer, const Schema::Info& info)
+            writer.String("title");
+            writer.String(info.title.c_str());
+            writer.String("version");
+            writer.String(info.version.c_str());
+            if (!info.description.empty())
             {
-                writer.String("swagger");
-                writer.String("2.0");
-                writer.String("info");
+                writer.String("description");
+                writer.String(info.description.c_str());
+            }
+            if (!info.termsOfService.empty())
+            {
+                writer.String("termsOfService");
+                writer.String(info.termsOfService.c_str());
+            }
+        }
+        writer.EndObject();
+    }
+
+    template <typename Writer>
+    void serializePC(Writer& writer, const Schema::ProduceConsume& pc)
+    {
+        auto serializeMimes = [&](const char* name,
+                                  const std::vector<Http::Mime::MediaType>& mimes) {
+            if (!mimes.empty())
+            {
+                writer.String(name);
+                writer.StartArray();
+                {
+                    for (const auto& mime : mimes)
+                    {
+                        auto str = mime.toString();
+                        writer.String(str.c_str());
+                    }
+                }
+                writer.EndArray();
+            }
+        };
+
+        serializeMimes("consumes", pc.consume);
+        serializeMimes("produces", pc.produce);
+    }
+
+    template <typename Writer>
+    void serializeParameter(Writer& writer, const Schema::Parameter& parameter)
+    {
+        writer.StartObject();
+        {
+            writer.String("name");
+            writer.String(parameter.name.c_str());
+            writer.String("in");
+            // @Feature: support other types of parameters
+            writer.String("path");
+            writer.String("description");
+            writer.String(parameter.description.c_str());
+            writer.String("required");
+            writer.Bool(parameter.required);
+            writer.String("type");
+            writer.String(parameter.type->typeName());
+        }
+        writer.EndObject();
+    }
+
+    template <typename Writer>
+    void serializeResponse(Writer& writer, const Schema::Response& response)
+    {
+        auto code = std::to_string(static_cast<uint32_t>(response.statusCode));
+        writer.String(code.c_str());
+        writer.StartObject();
+        {
+            writer.String("description");
+            writer.String(response.description.c_str());
+        }
+        writer.EndObject();
+    }
+
+    template <typename Writer>
+    void serializePath(Writer& writer, const Schema::Path& path)
+    {
+        std::string methodStr(methodString(path.method));
+        // So it looks like Swagger requires method to be in lowercase
+        std::transform(std::begin(methodStr), std::end(methodStr),
+                       std::begin(methodStr), ::tolower);
+
+        writer.String(methodStr.c_str());
+        writer.StartObject();
+        {
+            writer.String("description");
+            writer.String(path.description.c_str());
+            serializePC(writer, path.pc);
+
+            const auto& parameters = path.parameters;
+            if (!parameters.empty())
+            {
+                writer.String("parameters");
+                writer.StartArray();
+                {
+                    for (const auto& parameter : parameters)
+                    {
+                        serializeParameter(writer, parameter);
+                    }
+                }
+                writer.EndArray();
+            }
+
+            const auto& responses = path.responses;
+            if (!responses.empty())
+            {
+                writer.String("responses");
                 writer.StartObject();
                 {
-                    writer.String("title");
-                    writer.String(info.title.c_str());
-                    writer.String("version");
-                    writer.String(info.version.c_str());
-                    if (!info.description.empty())
+                    for (const auto& response : responses)
                     {
-                        writer.String("description");
-                        writer.String(info.description.c_str());
-                    }
-                    if (!info.termsOfService.empty())
-                    {
-                        writer.String("termsOfService");
-                        writer.String(info.termsOfService.c_str());
+                        serializeResponse(writer, response);
                     }
                 }
                 writer.EndObject();
             }
+        }
+        writer.EndObject();
+    }
 
-            template <typename Writer>
-            void serializePC(Writer& writer, const Schema::ProduceConsume& pc)
+    template <typename Writer>
+    void serializePathGroups(Writer& writer, const std::string& prefix,
+                             const Schema::PathGroup& paths,
+                             Schema::PathGroup::Format format)
+    {
+        writer.String("paths");
+        writer.StartObject();
+        {
+            auto groups = paths.groups();
+            for (const auto& group : groups)
             {
-                auto serializeMimes = [&](const char* name,
-                                          const std::vector<Http::Mime::MediaType>& mimes) {
-                    if (!mimes.empty())
+                if (group.second.isHidden())
+                    continue;
+
+                std::string name(group.first);
+                if (!prefix.empty())
+                {
+                    if (!name.compare(0, prefix.size(), prefix))
                     {
-                        writer.String(name);
-                        writer.StartArray();
-                        {
-                            for (const auto& mime : mimes)
-                            {
-                                auto str = mime.toString();
-                                writer.String(str.c_str());
-                            }
-                        }
-                        writer.EndArray();
+                        name = name.substr(prefix.size());
                     }
-                };
-
-                serializeMimes("consumes", pc.consume);
-                serializeMimes("produces", pc.produce);
-            }
-
-            template <typename Writer>
-            void serializeParameter(Writer& writer, const Schema::Parameter& parameter)
-            {
-                writer.StartObject();
-                {
-                    writer.String("name");
-                    writer.String(parameter.name.c_str());
-                    writer.String("in");
-                    // @Feature: support other types of parameters
-                    writer.String("path");
-                    writer.String("description");
-                    writer.String(parameter.description.c_str());
-                    writer.String("required");
-                    writer.Bool(parameter.required);
-                    writer.String("type");
-                    writer.String(parameter.type->typeName());
                 }
-                writer.EndObject();
-            }
 
-            template <typename Writer>
-            void serializeResponse(Writer& writer, const Schema::Response& response)
-            {
-                auto code = std::to_string(static_cast<uint32_t>(response.statusCode));
-                writer.String(code.c_str());
-                writer.StartObject();
+                if (format == Schema::PathGroup::Format::Default)
                 {
-                    writer.String("description");
-                    writer.String(response.description.c_str());
+                    writer.String(name.c_str());
                 }
-                writer.EndObject();
-            }
-
-            template <typename Writer>
-            void serializePath(Writer& writer, const Schema::Path& path)
-            {
-                std::string methodStr(methodString(path.method));
-                // So it looks like Swagger requires method to be in lowercase
-                std::transform(std::begin(methodStr), std::end(methodStr),
-                               std::begin(methodStr), ::tolower);
-
-                writer.String(methodStr.c_str());
+                else
+                {
+                    auto swaggerPath = Schema::Path::swaggerFormat(name);
+                    writer.String(swaggerPath.c_str());
+                }
                 writer.StartObject();
                 {
-                    writer.String("description");
-                    writer.String(path.description.c_str());
-                    serializePC(writer, path.pc);
-
-                    const auto& parameters = path.parameters;
-                    if (!parameters.empty())
+                    for (const auto& path : group.second)
                     {
-                        writer.String("parameters");
-                        writer.StartArray();
-                        {
-                            for (const auto& parameter : parameters)
-                            {
-                                serializeParameter(writer, parameter);
-                            }
-                        }
-                        writer.EndArray();
-                    }
-
-                    const auto& responses = path.responses;
-                    if (!responses.empty())
-                    {
-                        writer.String("responses");
-                        writer.StartObject();
-                        {
-                            for (const auto& response : responses)
-                            {
-                                serializeResponse(writer, response);
-                            }
-                        }
-                        writer.EndObject();
+                        if (!path.hidden)
+                            serializePath(writer, path);
                     }
                 }
                 writer.EndObject();
             }
+        }
+        writer.EndObject();
+    }
 
-            template <typename Writer>
-            void serializePathGroups(Writer& writer, const std::string& prefix,
-                                     const Schema::PathGroup& paths,
-                                     Schema::PathGroup::Format format)
+    template <typename Writer>
+    void serializeDescription(Writer& writer, const Description& desc)
+    {
+        writer.StartObject();
+        {
+            serializeInfo(writer, desc.rawInfo());
+            auto host         = desc.rawHost();
+            auto basePath     = desc.rawBasePath();
+            auto schemes      = desc.rawSchemes();
+            auto pc           = desc.rawPC();
+            const auto& paths = desc.rawPaths();
+
+            if (!host.empty())
             {
-                writer.String("paths");
-                writer.StartObject();
+                writer.String("host");
+                writer.String(host.c_str());
+            }
+            if (!basePath.empty())
+            {
+                writer.String("basePath");
+                writer.String(basePath.c_str());
+            }
+            if (!schemes.empty())
+            {
+                writer.String("schemes");
+                writer.StartArray();
                 {
-                    auto groups = paths.groups();
-                    for (const auto& group : groups)
+                    for (const auto& scheme : schemes)
                     {
-                        if (group.second.isHidden())
-                            continue;
-
-                        std::string name(group.first);
-                        if (!prefix.empty())
-                        {
-                            if (!name.compare(0, prefix.size(), prefix))
-                            {
-                                name = name.substr(prefix.size());
-                            }
-                        }
-
-                        if (format == Schema::PathGroup::Format::Default)
-                        {
-                            writer.String(name.c_str());
-                        }
-                        else
-                        {
-                            auto swaggerPath = Schema::Path::swaggerFormat(name);
-                            writer.String(swaggerPath.c_str());
-                        }
-                        writer.StartObject();
-                        {
-                            for (const auto& path : group.second)
-                            {
-                                if (!path.hidden)
-                                    serializePath(writer, path);
-                            }
-                        }
-                        writer.EndObject();
+                        writer.String(schemeString(scheme));
                     }
                 }
-                writer.EndObject();
+                writer.EndArray();
             }
+            serializePC(writer, pc);
+            serializePathGroups(writer, basePath, paths,
+                                Schema::PathGroup::Format::Swagger);
+        }
+        writer.EndObject();
+    }
 
-            template <typename Writer>
-            void serializeDescription(Writer& writer, const Description& desc)
-            {
-                writer.StartObject();
-                {
-                    serializeInfo(writer, desc.rawInfo());
-                    auto host     = desc.rawHost();
-                    auto basePath = desc.rawBasePath();
-                    auto schemes  = desc.rawSchemes();
-                    auto pc       = desc.rawPC();
-                    auto paths    = desc.rawPaths();
+    inline std::string rapidJson(const Description& desc)
+    {
+        rapidjson::StringBuffer sb;
+        rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(sb);
+        serializeDescription(writer, desc);
 
-                    if (!host.empty())
-                    {
-                        writer.String("host");
-                        writer.String(host.c_str());
-                    }
-                    if (!basePath.empty())
-                    {
-                        writer.String("basePath");
-                        writer.String(basePath.c_str());
-                    }
-                    if (!schemes.empty())
-                    {
-                        writer.String("schemes");
-                        writer.StartArray();
-                        {
-                            for (const auto& scheme : schemes)
-                            {
-                                writer.String(schemeString(scheme));
-                            }
-                        }
-                        writer.EndArray();
-                    }
-                    serializePC(writer, pc);
-                    serializePathGroups(writer, basePath, paths,
-                                        Schema::PathGroup::Format::Swagger);
-                }
-                writer.EndObject();
-            }
+        return sb.GetString();
+    }
 
-            inline std::string rapidJson(const Description& desc)
-            {
-                rapidjson::StringBuffer sb;
-                rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(sb);
-                serializeDescription(writer, desc);
-
-                return sb.GetString();
-            }
-
-        } // namespace Serializer
-    } // namespace Rest
-} // namespace Pistache
+} // namespace Pistache::Rest::Serializer

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -26,1056 +26,1039 @@
 #include <sstream>
 #include <string>
 
-namespace Pistache
+namespace Pistache::Http
 {
+    using NotifyOn = Polling::NotifyOn;
 
-    using namespace Polling;
+    static constexpr const char* UA = "pistache/0.1";
 
-    namespace Http
+    namespace
     {
-
-        static constexpr const char* UA = "pistache/0.1";
-
-        namespace
+        // Using const_cast can result in undefined behavior.
+        // C++17 provides a non-const .data() overload,
+        // but url must be passed as a non-const reference (or by value)
+        std::pair<std::string_view, std::string_view> splitUrl(const std::string& url)
         {
-            // Using const_cast can result in undefined behavior.
-            // C++17 provides a non-const .data() overload,
-            // but url must be passed as a non-const reference (or by value)
-            std::pair<std::string_view, std::string_view> splitUrl(const std::string& url)
-            {
-                RawStreamBuf<char> buf(const_cast<char*>(url.data()), url.size());
-                StreamCursor cursor(&buf);
+            RawStreamBuf<char> buf(const_cast<char*>(url.data()), url.size());
+            StreamCursor cursor(&buf);
 
-                match_string("http://", cursor);
-                match_string("www", cursor);
-                match_literal('.', cursor);
+            match_string("http://", cursor);
+            match_string("www", cursor);
+            match_literal('.', cursor);
 
-                StreamCursor::Token hostToken(cursor);
-                match_until({ '?', '/' }, cursor);
+            StreamCursor::Token hostToken(cursor);
+            match_until({ '?', '/' }, cursor);
 
-                std::string_view host(hostToken.rawText(), hostToken.size());
-                std::string_view page(cursor.offset(), buf.endptr() - buf.curptr());
+            std::string_view host(hostToken.rawText(), hostToken.size());
+            std::string_view page(cursor.offset(), buf.endptr() - buf.curptr());
 
-                return std::make_pair(host, page);
-            }
-        } // namespace
+            return std::make_pair(host, page);
+        }
+    } // namespace
 
-        namespace
+    namespace
+    {
+        template <typename H, typename... Args>
+        void writeHeader(std::stringstream& streamBuf, Args&&... args)
         {
-            template <typename H, typename... Args>
-            void writeHeader(std::stringstream& streamBuf, Args&&... args)
+            using Http::crlf;
+
+            H header(std::forward<Args>(args)...);
+
+            streamBuf << H::Name << ": ";
+            header.write(streamBuf);
+
+            streamBuf << crlf;
+        }
+
+        void writeHeaders(std::stringstream& streamBuf,
+                          const Http::Header::Collection& headers)
+        {
+            using Http::crlf;
+
+            for (const auto& header : headers.list())
             {
-                using Http::crlf;
-
-                H header(std::forward<Args>(args)...);
-
-                streamBuf << H::Name << ": ";
-                header.write(streamBuf);
-
+                streamBuf << header->name() << ": ";
+                header->write(streamBuf);
                 streamBuf << crlf;
             }
+        }
 
-            void writeHeaders(std::stringstream& streamBuf,
-                              const Http::Header::Collection& headers)
-            {
-                using Http::crlf;
-
-                for (const auto& header : headers.list())
-                {
-                    streamBuf << header->name() << ": ";
-                    header->write(streamBuf);
-                    streamBuf << crlf;
-                }
-            }
-
-            void writeCookies(std::stringstream& streamBuf,
-                              const Http::CookieJar& cookies)
-            {
-                using Http::crlf;
-
-                streamBuf << "Cookie: ";
-                bool first = true;
-                for (const auto& cookie : cookies)
-                {
-                    if (!first)
-                    {
-                        streamBuf << "; ";
-                    }
-                    else
-                    {
-                        first = false;
-                    }
-                    streamBuf << cookie.name << "=" << cookie.value;
-                }
-
-                streamBuf << crlf;
-            }
-
-            void writeRequest(std::stringstream& streamBuf, const Http::Request& request)
-            {
-                using Http::crlf;
-
-                const auto& res         = request.resource();
-                const auto [host, path] = splitUrl(res);
-                const auto& body        = request.body();
-                const auto& query       = request.query();
-
-                auto pathStr = std::string(path);
-
-                streamBuf << request.method() << " ";
-                if (pathStr[0] != '/')
-                    streamBuf << '/';
-
-                streamBuf << pathStr << query.as_str();
-                streamBuf << " HTTP/1.1" << crlf;
-
-                writeCookies(streamBuf, request.cookies());
-                writeHeaders(streamBuf, request.headers());
-
-                writeHeader<Http::Header::UserAgent>(streamBuf, UA);
-                writeHeader<Http::Header::Host>(streamBuf, std::string(host));
-                if (!body.empty())
-                {
-                    writeHeader<Http::Header::ContentLength>(streamBuf, body.size());
-                }
-                streamBuf << crlf;
-
-                if (!body.empty())
-                {
-                    streamBuf << body;
-                }
-            }
-        } // namespace
-
-        class Transport : public Aio::Handler
+        void writeCookies(std::stringstream& streamBuf,
+                          const Http::CookieJar& cookies)
         {
-        public:
-            PROTOTYPE_OF(Aio::Handler, Transport)
+            using Http::crlf;
 
-            Transport() = default;
-            Transport(const Transport&)
-                : requestsQueue()
-                , connectionsQueue()
-                , connections()
-                , timeouts()
-                , timeoutsLock()
-            { }
-
-            void onReady(const Aio::FdSet& fds) override;
-            void registerPoller(Polling::Epoll& poller) override;
-
-            Async::Promise<void> asyncConnect(std::shared_ptr<Connection> connection,
-                                              const struct sockaddr* address,
-                                              socklen_t addr_len);
-
-            Async::Promise<ssize_t>
-            asyncSendRequest(std::shared_ptr<Connection> connection,
-                             std::shared_ptr<TimerPool::Entry> timer, std::string buffer);
-
-        private:
-            enum WriteStatus { FirstTry,
-                               Retry };
-
-            struct ConnectionEntry
+            streamBuf << "Cookie: ";
+            bool first = true;
+            for (const auto& cookie : cookies)
             {
-                ConnectionEntry(Async::Resolver resolve, Async::Rejection reject,
-                                std::shared_ptr<Connection> connection,
-                                const struct sockaddr* _addr, socklen_t _addr_len)
-                    : resolve(std::move(resolve))
-                    , reject(std::move(reject))
-                    , connection(connection)
-                    , addr_len(_addr_len)
+                if (!first)
                 {
-                    memcpy(&addr, _addr, addr_len);
-                }
-
-                const sockaddr* getAddr() const
-                {
-                    return reinterpret_cast<const sockaddr*>(&addr);
-                }
-
-                Async::Resolver resolve;
-                Async::Rejection reject;
-                std::weak_ptr<Connection> connection;
-                sockaddr_storage addr;
-                socklen_t addr_len;
-            };
-
-            struct RequestEntry
-            {
-                RequestEntry(Async::Resolver resolve, Async::Rejection reject,
-                             std::shared_ptr<Connection> connection,
-                             std::shared_ptr<TimerPool::Entry> timer, std::string buf)
-                    : resolve(std::move(resolve))
-                    , reject(std::move(reject))
-                    , connection(connection)
-                    , timer(timer)
-                    , buffer(std::move(buf))
-                { }
-
-                Async::Resolver resolve;
-                Async::Rejection reject;
-                std::weak_ptr<Connection> connection;
-                std::shared_ptr<TimerPool::Entry> timer;
-                std::string buffer;
-            };
-
-            PollableQueue<RequestEntry> requestsQueue;
-            PollableQueue<ConnectionEntry> connectionsQueue;
-
-            std::unordered_map<Fd, ConnectionEntry> connections;
-            std::unordered_map<Fd, std::weak_ptr<Connection>> timeouts;
-
-            using Lock  = std::mutex;
-            using Guard = std::lock_guard<Lock>;
-            Lock timeoutsLock;
-
-        private:
-            void asyncSendRequestImpl(const RequestEntry& req,
-                                      WriteStatus status = FirstTry);
-
-            void handleRequestsQueue();
-            void handleConnectionQueue();
-            void handleReadableEntry(const Aio::FdSet::Entry& entry);
-            void handleWritableEntry(const Aio::FdSet::Entry& entry);
-            void handleHangupEntry(const Aio::FdSet::Entry& entry);
-            void handleIncoming(std::shared_ptr<Connection> connection);
-        };
-
-        void Transport::onReady(const Aio::FdSet& fds)
-        {
-            for (const auto& entry : fds)
-            {
-                if (entry.getTag() == connectionsQueue.tag())
-                {
-                    handleConnectionQueue();
-                }
-                else if (entry.getTag() == requestsQueue.tag())
-                {
-                    handleRequestsQueue();
-                }
-                else if (entry.isReadable())
-                {
-                    handleReadableEntry(entry);
-                }
-                else if (entry.isWritable())
-                {
-                    handleWritableEntry(entry);
-                }
-                else if (entry.isHangup())
-                {
-                    handleHangupEntry(entry);
+                    streamBuf << "; ";
                 }
                 else
                 {
-                    assert(false && "Unexpected event in entry");
+                    first = false;
                 }
+                streamBuf << cookie.name << "=" << cookie.value;
+            }
+
+            streamBuf << crlf;
+        }
+
+        void writeRequest(std::stringstream& streamBuf, const Http::Request& request)
+        {
+            using Http::crlf;
+
+            const auto& res         = request.resource();
+            const auto [host, path] = splitUrl(res);
+            const auto& body        = request.body();
+            const auto& query       = request.query();
+
+            auto pathStr = std::string(path);
+
+            streamBuf << request.method() << " ";
+            if (pathStr[0] != '/')
+                streamBuf << '/';
+
+            streamBuf << pathStr << query.as_str();
+            streamBuf << " HTTP/1.1" << crlf;
+
+            writeCookies(streamBuf, request.cookies());
+            writeHeaders(streamBuf, request.headers());
+
+            writeHeader<Http::Header::UserAgent>(streamBuf, UA);
+            writeHeader<Http::Header::Host>(streamBuf, std::string(host));
+            if (!body.empty())
+            {
+                writeHeader<Http::Header::ContentLength>(streamBuf, body.size());
+            }
+            streamBuf << crlf;
+
+            if (!body.empty())
+            {
+                streamBuf << body;
             }
         }
+    } // namespace
 
-        void Transport::registerPoller(Polling::Epoll& poller)
-        {
-            requestsQueue.bind(poller);
-            connectionsQueue.bind(poller);
-        }
+    class Transport : public Aio::Handler
+    {
+    public:
+        PROTOTYPE_OF(Aio::Handler, Transport)
 
-        Async::Promise<void>
-        Transport::asyncConnect(std::shared_ptr<Connection> connection,
-                                const struct sockaddr* address, socklen_t addr_len)
-        {
-            return Async::Promise<void>(
-                [=](Async::Resolver& resolve, Async::Rejection& reject) {
-                    ConnectionEntry entry(std::move(resolve), std::move(reject), connection,
-                                          address, addr_len);
-                    connectionsQueue.push(std::move(entry));
-                });
-        }
+        Transport() = default;
+        Transport(const Transport&)
+            : requestsQueue()
+            , connectionsQueue()
+            , connections()
+            , timeouts()
+            , timeoutsLock()
+        { }
+
+        void onReady(const Aio::FdSet& fds) override;
+        void registerPoller(Polling::Epoll& poller) override;
+
+        Async::Promise<void> asyncConnect(std::shared_ptr<Connection> connection,
+                                          const struct sockaddr* address,
+                                          socklen_t addr_len);
 
         Async::Promise<ssize_t>
-        Transport::asyncSendRequest(std::shared_ptr<Connection> connection,
-                                    std::shared_ptr<TimerPool::Entry> timer,
-                                    std::string buffer)
+        asyncSendRequest(std::shared_ptr<Connection> connection,
+                         std::shared_ptr<TimerPool::Entry> timer, std::string buffer);
+
+    private:
+        enum WriteStatus { FirstTry,
+                           Retry };
+
+        struct ConnectionEntry
         {
-
-            return Async::Promise<ssize_t>(
-                [&](Async::Resolver& resolve, Async::Rejection& reject) {
-                    auto ctx = context();
-                    RequestEntry req(std::move(resolve), std::move(reject), connection,
-                                     timer, std::move(buffer));
-                    if (std::this_thread::get_id() != ctx.thread())
-                    {
-                        requestsQueue.push(std::move(req));
-                    }
-                    else
-                    {
-                        asyncSendRequestImpl(req);
-                    }
-                });
-        }
-
-        void Transport::asyncSendRequestImpl(const RequestEntry& req,
-                                             WriteStatus status)
-        {
-            const auto& buffer = req.buffer;
-            auto conn          = req.connection.lock();
-            if (!conn)
-                throw std::runtime_error("Send request error");
-
-            auto fd = conn->fd();
-
-            ssize_t totalWritten = 0;
-            for (;;)
+            ConnectionEntry(Async::Resolver resolve, Async::Rejection reject,
+                            std::shared_ptr<Connection> connection,
+                            const struct sockaddr* _addr, socklen_t _addr_len)
+                : resolve(std::move(resolve))
+                , reject(std::move(reject))
+                , connection(connection)
+                , addr_len(_addr_len)
             {
-                const char* data           = buffer.data() + totalWritten;
-                const ssize_t len          = buffer.size() - totalWritten;
-                const ssize_t bytesWritten = ::send(fd, data, len, 0);
-                if (bytesWritten < 0)
+                memcpy(&addr, _addr, addr_len);
+            }
+
+            const sockaddr* getAddr() const
+            {
+                return reinterpret_cast<const sockaddr*>(&addr);
+            }
+
+            Async::Resolver resolve;
+            Async::Rejection reject;
+            std::weak_ptr<Connection> connection;
+            sockaddr_storage addr;
+            socklen_t addr_len;
+        };
+
+        struct RequestEntry
+        {
+            RequestEntry(Async::Resolver resolve, Async::Rejection reject,
+                         std::shared_ptr<Connection> connection,
+                         std::shared_ptr<TimerPool::Entry> timer, std::string buf)
+                : resolve(std::move(resolve))
+                , reject(std::move(reject))
+                , connection(connection)
+                , timer(timer)
+                , buffer(std::move(buf))
+            { }
+
+            Async::Resolver resolve;
+            Async::Rejection reject;
+            std::weak_ptr<Connection> connection;
+            std::shared_ptr<TimerPool::Entry> timer;
+            std::string buffer;
+        };
+
+        PollableQueue<RequestEntry> requestsQueue;
+        PollableQueue<ConnectionEntry> connectionsQueue;
+
+        std::unordered_map<Fd, ConnectionEntry> connections;
+        std::unordered_map<Fd, std::weak_ptr<Connection>> timeouts;
+
+        using Lock  = std::mutex;
+        using Guard = std::lock_guard<Lock>;
+        Lock timeoutsLock;
+
+    private:
+        void asyncSendRequestImpl(const RequestEntry& req,
+                                  WriteStatus status = FirstTry);
+
+        void handleRequestsQueue();
+        void handleConnectionQueue();
+        void handleReadableEntry(const Aio::FdSet::Entry& entry);
+        void handleWritableEntry(const Aio::FdSet::Entry& entry);
+        void handleHangupEntry(const Aio::FdSet::Entry& entry);
+        void handleIncoming(std::shared_ptr<Connection> connection);
+    };
+
+    void Transport::onReady(const Aio::FdSet& fds)
+    {
+        for (const auto& entry : fds)
+        {
+            if (entry.getTag() == connectionsQueue.tag())
+            {
+                handleConnectionQueue();
+            }
+            else if (entry.getTag() == requestsQueue.tag())
+            {
+                handleRequestsQueue();
+            }
+            else if (entry.isReadable())
+            {
+                handleReadableEntry(entry);
+            }
+            else if (entry.isWritable())
+            {
+                handleWritableEntry(entry);
+            }
+            else if (entry.isHangup())
+            {
+                handleHangupEntry(entry);
+            }
+            else
+            {
+                assert(false && "Unexpected event in entry");
+            }
+        }
+    }
+
+    void Transport::registerPoller(Polling::Epoll& poller)
+    {
+        requestsQueue.bind(poller);
+        connectionsQueue.bind(poller);
+    }
+
+    Async::Promise<void>
+    Transport::asyncConnect(std::shared_ptr<Connection> connection,
+                            const struct sockaddr* address, socklen_t addr_len)
+    {
+        return Async::Promise<void>(
+            [=](Async::Resolver& resolve, Async::Rejection& reject) {
+                ConnectionEntry entry(std::move(resolve), std::move(reject), connection,
+                                      address, addr_len);
+                connectionsQueue.push(std::move(entry));
+            });
+    }
+
+    Async::Promise<ssize_t>
+    Transport::asyncSendRequest(std::shared_ptr<Connection> connection,
+                                std::shared_ptr<TimerPool::Entry> timer,
+                                std::string buffer)
+    {
+
+        return Async::Promise<ssize_t>(
+            [&](Async::Resolver& resolve, Async::Rejection& reject) {
+                auto ctx = context();
+                RequestEntry req(std::move(resolve), std::move(reject), connection,
+                                 timer, std::move(buffer));
+                if (std::this_thread::get_id() != ctx.thread())
                 {
-                    if (errno == EAGAIN || errno == EWOULDBLOCK)
-                    {
-                        if (status == FirstTry)
-                        {
-                            throw std::runtime_error("Unimplemented, fix me!");
-                        }
-                        reactor()->modifyFd(key(), fd, NotifyOn::Write, Polling::Mode::Edge);
-                    }
-                    else
-                    {
-                        conn->handleError("Could not send request");
-                    }
-                    break;
+                    requestsQueue.push(std::move(req));
                 }
                 else
                 {
-                    totalWritten += bytesWritten;
-                    if (totalWritten == len)
+                    asyncSendRequestImpl(req);
+                }
+            });
+    }
+
+    void Transport::asyncSendRequestImpl(const RequestEntry& req,
+                                         WriteStatus status)
+    {
+        const auto& buffer = req.buffer;
+        auto conn          = req.connection.lock();
+        if (!conn)
+            throw std::runtime_error("Send request error");
+
+        auto fd = conn->fd();
+
+        ssize_t totalWritten = 0;
+        for (;;)
+        {
+            const char* data           = buffer.data() + totalWritten;
+            const ssize_t len          = buffer.size() - totalWritten;
+            const ssize_t bytesWritten = ::send(fd, data, len, 0);
+            if (bytesWritten < 0)
+            {
+                if (errno == EAGAIN || errno == EWOULDBLOCK)
+                {
+                    if (status == FirstTry)
                     {
-                        if (req.timer)
-                        {
-                            Guard guard(timeoutsLock);
-                            timeouts.insert(std::make_pair(req.timer->fd(), conn));
-                            req.timer->registerReactor(key(), reactor());
-                        }
-                        req.resolve(totalWritten);
-                        break;
+                        throw std::runtime_error("Unimplemented, fix me!");
                     }
+                    reactor()->modifyFd(key(), fd, NotifyOn::Write, Polling::Mode::Edge);
+                }
+                else
+                {
+                    conn->handleError("Could not send request");
+                }
+                break;
+            }
+            else
+            {
+                totalWritten += bytesWritten;
+                if (totalWritten == len)
+                {
+                    if (req.timer)
+                    {
+                        Guard guard(timeoutsLock);
+                        timeouts.insert(std::make_pair(req.timer->fd(), conn));
+                        req.timer->registerReactor(key(), reactor());
+                    }
+                    req.resolve(totalWritten);
+                    break;
                 }
             }
         }
+    }
 
-        void Transport::handleRequestsQueue()
+    void Transport::handleRequestsQueue()
+    {
+        // Let's drain the queue
+        for (;;)
         {
-            // Let's drain the queue
-            for (;;)
-            {
-                auto req = requestsQueue.popSafe();
-                if (!req)
-                    break;
+            auto req = requestsQueue.popSafe();
+            if (!req)
+                break;
 
-                asyncSendRequestImpl(*req);
-            }
+            asyncSendRequestImpl(*req);
         }
+    }
 
-        void Transport::handleConnectionQueue()
+    void Transport::handleConnectionQueue()
+    {
+        for (;;)
         {
-            for (;;)
-            {
-                auto data = connectionsQueue.popSafe();
-                if (!data)
-                    break;
+            auto data = connectionsQueue.popSafe();
+            if (!data)
+                break;
 
-                auto conn = data->connection.lock();
-                if (!conn)
+            auto conn = data->connection.lock();
+            if (!conn)
+            {
+                data->reject(Error::system("Failed to connect"));
+                continue;
+            }
+
+            int res = ::connect(conn->fd(), data->getAddr(), data->addr_len);
+            if (res == -1)
+            {
+                if (errno == EINPROGRESS)
+                {
+                    reactor()->registerFdOneShot(key(), conn->fd(),
+                                                 NotifyOn::Write | NotifyOn::Hangup | NotifyOn::Shutdown);
+                }
+                else
                 {
                     data->reject(Error::system("Failed to connect"));
                     continue;
                 }
+            }
+            connections.insert(std::make_pair(conn->fd(), std::move(*data)));
+        }
+    }
 
-                int res = ::connect(conn->fd(), data->getAddr(), data->addr_len);
-                if (res == -1)
-                {
-                    if (errno == EINPROGRESS)
-                    {
-                        reactor()->registerFdOneShot(key(), conn->fd(),
-                                                     NotifyOn::Write | NotifyOn::Hangup | NotifyOn::Shutdown);
-                    }
-                    else
-                    {
-                        data->reject(Error::system("Failed to connect"));
-                        continue;
-                    }
-                }
-                connections.insert(std::make_pair(conn->fd(), std::move(*data)));
+    void Transport::handleReadableEntry(const Aio::FdSet::Entry& entry)
+    {
+        assert(entry.isReadable() && "Entry must be readable");
+
+        auto tag      = entry.getTag();
+        const auto fd = static_cast<Fd>(tag.value());
+        auto connIt   = connections.find(fd);
+        if (connIt != std::end(connections))
+        {
+            auto connection = connIt->second.connection.lock();
+            if (connection)
+            {
+                handleIncoming(connection);
+            }
+            else
+            {
+                throw std::runtime_error(
+                    "Connection error: problem with reading data from server");
             }
         }
-
-        void Transport::handleReadableEntry(const Aio::FdSet::Entry& entry)
+        else
         {
-            assert(entry.isReadable() && "Entry must be readable");
-
-            auto tag      = entry.getTag();
-            const auto fd = static_cast<Fd>(tag.value());
-            auto connIt   = connections.find(fd);
-            if (connIt != std::end(connections))
+            Guard guard(timeoutsLock);
+            auto timerIt = timeouts.find(fd);
+            if (timerIt != std::end(timeouts))
             {
-                auto connection = connIt->second.connection.lock();
+                auto connection = timerIt->second.lock();
                 if (connection)
                 {
-                    handleIncoming(connection);
+                    connection->handleTimeout();
+                    timeouts.erase(fd);
                 }
-                else
-                {
-                    throw std::runtime_error(
-                        "Connection error: problem with reading data from server");
-                }
+            }
+        }
+    }
+
+    void Transport::handleWritableEntry(const Aio::FdSet::Entry& entry)
+    {
+        assert(entry.isWritable() && "Entry must be writable");
+
+        auto tag      = entry.getTag();
+        const auto fd = static_cast<Fd>(tag.value());
+        auto connIt   = connections.find(fd);
+        if (connIt != std::end(connections))
+        {
+            auto& connectionEntry = connIt->second;
+            auto connection       = connIt->second.connection.lock();
+            if (connection)
+            {
+                connectionEntry.resolve();
+                // We are connected, we can start reading data now
+                reactor()->modifyFd(key(), connection->fd(), NotifyOn::Read);
             }
             else
             {
-                Guard guard(timeoutsLock);
-                auto timerIt = timeouts.find(fd);
-                if (timerIt != std::end(timeouts))
-                {
-                    auto connection = timerIt->second.lock();
-                    if (connection)
-                    {
-                        connection->handleTimeout();
-                        timeouts.erase(fd);
-                    }
-                }
+                connectionEntry.reject(Error::system("Connection lost"));
             }
         }
-
-        void Transport::handleWritableEntry(const Aio::FdSet::Entry& entry)
+        else
         {
-            assert(entry.isWritable() && "Entry must be writable");
-
-            auto tag      = entry.getTag();
-            const auto fd = static_cast<Fd>(tag.value());
-            auto connIt   = connections.find(fd);
-            if (connIt != std::end(connections))
-            {
-                auto& connectionEntry = connIt->second;
-                auto connection       = connIt->second.connection.lock();
-                if (connection)
-                {
-                    connectionEntry.resolve();
-                    // We are connected, we can start reading data now
-                    reactor()->modifyFd(key(), connection->fd(), NotifyOn::Read);
-                }
-                else
-                {
-                    connectionEntry.reject(Error::system("Connection lost"));
-                }
-            }
-            else
-            {
-                throw std::runtime_error("Unknown fd");
-            }
+            throw std::runtime_error("Unknown fd");
         }
+    }
 
-        void Transport::handleHangupEntry(const Aio::FdSet::Entry& entry)
+    void Transport::handleHangupEntry(const Aio::FdSet::Entry& entry)
+    {
+        assert(entry.isHangup() && "Entry must be hangup");
+
+        auto tag      = entry.getTag();
+        const auto fd = static_cast<Fd>(tag.value());
+        auto connIt   = connections.find(fd);
+        if (connIt != std::end(connections))
         {
-            assert(entry.isHangup() && "Entry must be hangup");
-
-            auto tag      = entry.getTag();
-            const auto fd = static_cast<Fd>(tag.value());
-            auto connIt   = connections.find(fd);
-            if (connIt != std::end(connections))
-            {
-                auto& connectionEntry = connIt->second;
-                connectionEntry.reject(Error::system("Could not connect"));
-            }
-            else
-            {
-                throw std::runtime_error("Unknown fd");
-            }
+            auto& connectionEntry = connIt->second;
+            connectionEntry.reject(Error::system("Could not connect"));
         }
-
-        void Transport::handleIncoming(std::shared_ptr<Connection> connection)
+        else
         {
-            ssize_t totalBytes = 0;
-
-            for (;;)
-            {
-                char buffer[Const::MaxBuffer] = {
-                    0,
-                };
-                const ssize_t bytes = recv(connection->fd(), buffer, Const::MaxBuffer, 0);
-                if (bytes == -1)
-                {
-                    if (errno != EAGAIN && errno != EWOULDBLOCK)
-                    {
-                        connection->handleError(strerror(errno));
-                    }
-                    break;
-                }
-                else if (bytes == 0)
-                {
-                    if (totalBytes == 0)
-                    {
-                        connection->handleError("Remote closed connection");
-                    }
-                    connections.erase(connection->fd());
-                    connection->close();
-                    break;
-                }
-                else
-                {
-                    totalBytes += bytes;
-                    connection->handleResponsePacket(buffer, bytes);
-                }
-            }
+            throw std::runtime_error("Unknown fd");
         }
+    }
 
-        Connection::Connection(size_t maxResponseSize)
-            : fd_(-1)
-            , requestEntry(nullptr)
-            , parser(maxResponseSize)
+    void Transport::handleIncoming(std::shared_ptr<Connection> connection)
+    {
+        ssize_t totalBytes = 0;
+
+        for (;;)
         {
-            state_.store(static_cast<uint32_t>(State::Idle));
-            connectionState_.store(NotConnected);
-        }
-
-        void Connection::connect(const Address& addr)
-        {
-            struct addrinfo hints;
-            memset(&hints, 0, sizeof(struct addrinfo));
-            hints.ai_family   = addr.family();
-            hints.ai_socktype = SOCK_STREAM; /* Stream socket */
-            hints.ai_flags    = 0;
-            hints.ai_protocol = 0;
-
-            const auto& host = addr.host();
-            const auto& port = addr.port().toString();
-
-            AddrInfo addressInfo;
-
-            TRY(addressInfo.invoke(host.c_str(), port.c_str(), &hints));
-            const addrinfo* addrs = addressInfo.get_info_ptr();
-
-            int sfd = -1;
-
-            for (const addrinfo* addr = addrs; addr; addr = addr->ai_next)
+            char buffer[Const::MaxBuffer] = {
+                0,
+            };
+            const ssize_t bytes = recv(connection->fd(), buffer, Const::MaxBuffer, 0);
+            if (bytes == -1)
             {
-                sfd = ::socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
-                if (sfd < 0)
-                    continue;
-
-                make_non_blocking(sfd);
-
-                connectionState_.store(Connecting);
-                fd_ = sfd;
-
-                transport_
-                    ->asyncConnect(shared_from_this(), addr->ai_addr, addr->ai_addrlen)
-                    .then(
-                        [=]() {
-                            socklen_t len = sizeof(saddr);
-                            getsockname(sfd, reinterpret_cast<struct sockaddr*>(&saddr), &len);
-                            connectionState_.store(Connected);
-                            processRequestQueue();
-                        },
-                        PrintException());
+                if (errno != EAGAIN && errno != EWOULDBLOCK)
+                {
+                    connection->handleError(strerror(errno));
+                }
                 break;
             }
+            else if (bytes == 0)
+            {
+                if (totalBytes == 0)
+                {
+                    connection->handleError("Remote closed connection");
+                }
+                connections.erase(connection->fd());
+                connection->close();
+                break;
+            }
+            else
+            {
+                totalBytes += bytes;
+                connection->handleResponsePacket(buffer, bytes);
+            }
+        }
+    }
 
+    Connection::Connection(size_t maxResponseSize)
+        : fd_(-1)
+        , requestEntry(nullptr)
+        , parser(maxResponseSize)
+    {
+        state_.store(static_cast<uint32_t>(State::Idle));
+        connectionState_.store(NotConnected);
+    }
+
+    void Connection::connect(const Address& addr)
+    {
+        struct addrinfo hints;
+        memset(&hints, 0, sizeof(struct addrinfo));
+        hints.ai_family   = addr.family();
+        hints.ai_socktype = SOCK_STREAM; /* Stream socket */
+        hints.ai_flags    = 0;
+        hints.ai_protocol = 0;
+
+        const auto& host = addr.host();
+        const auto& port = addr.port().toString();
+
+        AddrInfo addressInfo;
+
+        TRY(addressInfo.invoke(host.c_str(), port.c_str(), &hints));
+        const addrinfo* addrs = addressInfo.get_info_ptr();
+
+        int sfd = -1;
+
+        for (const addrinfo* addr = addrs; addr; addr = addr->ai_next)
+        {
+            sfd = ::socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
             if (sfd < 0)
-                throw std::runtime_error("Failed to connect");
+                continue;
+
+            make_non_blocking(sfd);
+
+            connectionState_.store(Connecting);
+            fd_ = sfd;
+
+            transport_
+                ->asyncConnect(shared_from_this(), addr->ai_addr, addr->ai_addrlen)
+                .then(
+                    [=]() {
+                        socklen_t len = sizeof(saddr);
+                        getsockname(sfd, reinterpret_cast<struct sockaddr*>(&saddr), &len);
+                        connectionState_.store(Connected);
+                        processRequestQueue();
+                    },
+                    PrintException());
+            break;
         }
 
-        std::string Connection::dump() const
+        if (sfd < 0)
+            throw std::runtime_error("Failed to connect");
+    }
+
+    std::string Connection::dump() const
+    {
+        std::ostringstream oss;
+        oss << "Connection(fd = " << fd_ << ", src_port = ";
+        oss << ntohs(saddr.sin_port) << ")";
+        return oss.str();
+    }
+
+    bool Connection::isIdle() const
+    {
+        return static_cast<Connection::State>(state_.load()) == Connection::State::Idle;
+    }
+
+    bool Connection::tryUse()
+    {
+        auto curState = static_cast<uint32_t>(Connection::State::Idle);
+        auto newState = static_cast<uint32_t>(Connection::State::Used);
+        return state_.compare_exchange_strong(curState, newState);
+    }
+
+    void Connection::setAsIdle()
+    {
+        state_.store(static_cast<uint32_t>(Connection::State::Idle));
+    }
+
+    bool Connection::isConnected() const
+    {
+        return connectionState_.load() == Connected;
+    }
+
+    void Connection::close()
+    {
+        connectionState_.store(NotConnected);
+        ::close(fd_);
+    }
+
+    void Connection::associateTransport(
+        const std::shared_ptr<Transport>& transport)
+    {
+        if (transport_)
+            throw std::runtime_error(
+                "A transport has already been associated to the connection");
+
+        transport_ = transport;
+    }
+
+    bool Connection::hasTransport() const { return transport_ != nullptr; }
+
+    Fd Connection::fd() const
+    {
+        assert(fd_ != -1);
+        return fd_;
+    }
+
+    void Connection::handleResponsePacket(const char* buffer, size_t totalBytes)
+    {
+        try
         {
-            std::ostringstream oss;
-            oss << "Connection(fd = " << fd_ << ", src_port = ";
-            oss << ntohs(saddr.sin_port) << ")";
-            return oss.str();
-        }
-
-        bool Connection::isIdle() const
-        {
-            return static_cast<Connection::State>(state_.load()) == Connection::State::Idle;
-        }
-
-        bool Connection::tryUse()
-        {
-            auto curState = static_cast<uint32_t>(Connection::State::Idle);
-            auto newState = static_cast<uint32_t>(Connection::State::Used);
-            return state_.compare_exchange_strong(curState, newState);
-        }
-
-        void Connection::setAsIdle()
-        {
-            state_.store(static_cast<uint32_t>(Connection::State::Idle));
-        }
-
-        bool Connection::isConnected() const
-        {
-            return connectionState_.load() == Connected;
-        }
-
-        void Connection::close()
-        {
-            connectionState_.store(NotConnected);
-            ::close(fd_);
-        }
-
-        void Connection::associateTransport(
-            const std::shared_ptr<Transport>& transport)
-        {
-            if (transport_)
-                throw std::runtime_error(
-                    "A transport has already been associated to the connection");
-
-            transport_ = transport;
-        }
-
-        bool Connection::hasTransport() const { return transport_ != nullptr; }
-
-        Fd Connection::fd() const
-        {
-            assert(fd_ != -1);
-            return fd_;
-        }
-
-        void Connection::handleResponsePacket(const char* buffer, size_t totalBytes)
-        {
-            try
+            const bool result = parser.feed(buffer, totalBytes);
+            if (!result)
             {
-                const bool result = parser.feed(buffer, totalBytes);
-                if (!result)
+                handleError("Client: Too long packet");
+                return;
+            }
+            if (parser.parse() == Private::State::Done)
+            {
+                if (requestEntry)
                 {
-                    handleError("Client: Too long packet");
-                    return;
-                }
-                if (parser.parse() == Private::State::Done)
-                {
-                    if (requestEntry)
+                    if (requestEntry->timer)
                     {
-                        if (requestEntry->timer)
-                        {
-                            requestEntry->timer->disarm();
-                            timerPool_.releaseTimer(requestEntry->timer);
-                        }
-
-                        requestEntry->resolve(std::move(parser.response));
-                        parser.reset();
-
-                        auto onDone = requestEntry->onDone;
-
-                        requestEntry.reset(nullptr);
-
-                        if (onDone)
-                            onDone();
+                        requestEntry->timer->disarm();
+                        timerPool_.releaseTimer(requestEntry->timer);
                     }
+
+                    requestEntry->resolve(std::move(parser.response));
+                    parser.reset();
+
+                    auto onDone = requestEntry->onDone;
+
+                    requestEntry.reset(nullptr);
+
+                    if (onDone)
+                        onDone();
                 }
             }
-            catch (const std::exception& ex)
-            {
-                handleError(ex.what());
-            }
         }
-
-        void Connection::handleError(const char* error)
+        catch (const std::exception& ex)
         {
-            if (requestEntry)
-            {
-                if (requestEntry->timer)
-                {
-                    requestEntry->timer->disarm();
-                    timerPool_.releaseTimer(requestEntry->timer);
-                }
-
-                auto onDone = requestEntry->onDone;
-
-                requestEntry->reject(Error(error));
-
-                requestEntry.reset(nullptr);
-
-                if (onDone)
-                    onDone();
-            }
+            handleError(ex.what());
         }
+    }
 
-        void Connection::handleTimeout()
+    void Connection::handleError(const char* error)
+    {
+        if (requestEntry)
         {
-            if (requestEntry)
+            if (requestEntry->timer)
             {
                 requestEntry->timer->disarm();
                 timerPool_.releaseTimer(requestEntry->timer);
-
-                auto onDone = requestEntry->onDone;
-
-                /* @API: create a TimeoutException */
-                requestEntry->reject(std::runtime_error("Timeout"));
-
-                requestEntry.reset(nullptr);
-
-                if (onDone)
-                    onDone();
-            }
-        }
-
-        Async::Promise<Response> Connection::perform(const Http::Request& request,
-                                                     Connection::OnDone onDone)
-        {
-            return Async::Promise<Response>(
-                [=](Async::Resolver& resolve, Async::Rejection& reject) {
-                    performImpl(request, std::move(resolve), std::move(reject),
-                                std::move(onDone));
-                });
-        }
-
-        Async::Promise<Response> Connection::asyncPerform(const Http::Request& request,
-                                                          Connection::OnDone onDone)
-        {
-            return Async::Promise<Response>(
-                [=](Async::Resolver& resolve, Async::Rejection& reject) {
-                    requestsQueue.push(RequestData(std::move(resolve), std::move(reject),
-                                                   request, std::move(onDone)));
-                });
-        }
-
-        void Connection::performImpl(const Http::Request& request,
-                                     Async::Resolver resolve, Async::Rejection reject,
-                                     Connection::OnDone onDone)
-        {
-
-            std::stringstream streamBuf;
-            writeRequest(streamBuf, request);
-            if (!streamBuf)
-                reject(std::runtime_error("Could not write request"));
-            std::string buffer = streamBuf.str();
-
-            std::shared_ptr<TimerPool::Entry> timer(nullptr);
-            auto timeout = request.timeout();
-            if (timeout.count() > 0)
-            {
-                timer = timerPool_.pickTimer();
-                timer->arm(timeout);
             }
 
-            requestEntry.reset(new RequestEntry(std::move(resolve), std::move(reject),
-                                                timer, std::move(onDone)));
-            transport_->asyncSendRequest(shared_from_this(), timer, std::move(buffer));
+            auto onDone = requestEntry->onDone;
+
+            requestEntry->reject(Error(error));
+
+            requestEntry.reset(nullptr);
+
+            if (onDone)
+                onDone();
+        }
+    }
+
+    void Connection::handleTimeout()
+    {
+        if (requestEntry)
+        {
+            requestEntry->timer->disarm();
+            timerPool_.releaseTimer(requestEntry->timer);
+
+            auto onDone = requestEntry->onDone;
+
+            /* @API: create a TimeoutException */
+            requestEntry->reject(std::runtime_error("Timeout"));
+
+            requestEntry.reset(nullptr);
+
+            if (onDone)
+                onDone();
+        }
+    }
+
+    Async::Promise<Response> Connection::perform(const Http::Request& request,
+                                                 Connection::OnDone onDone)
+    {
+        return Async::Promise<Response>(
+            [=](Async::Resolver& resolve, Async::Rejection& reject) {
+                performImpl(request, std::move(resolve), std::move(reject),
+                            std::move(onDone));
+            });
+    }
+
+    Async::Promise<Response> Connection::asyncPerform(const Http::Request& request,
+                                                      Connection::OnDone onDone)
+    {
+        return Async::Promise<Response>(
+            [=](Async::Resolver& resolve, Async::Rejection& reject) {
+                requestsQueue.push(RequestData(std::move(resolve), std::move(reject),
+                                               request, std::move(onDone)));
+            });
+    }
+
+    void Connection::performImpl(const Http::Request& request,
+                                 Async::Resolver resolve, Async::Rejection reject,
+                                 Connection::OnDone onDone)
+    {
+
+        std::stringstream streamBuf;
+        writeRequest(streamBuf, request);
+        if (!streamBuf)
+            reject(std::runtime_error("Could not write request"));
+        std::string buffer = streamBuf.str();
+
+        std::shared_ptr<TimerPool::Entry> timer(nullptr);
+        auto timeout = request.timeout();
+        if (timeout.count() > 0)
+        {
+            timer = timerPool_.pickTimer();
+            timer->arm(timeout);
         }
 
-        void Connection::processRequestQueue()
-        {
-            for (;;)
-            {
-                auto req = requestsQueue.popSafe();
-                if (!req)
-                    break;
+        requestEntry = std::make_unique<RequestEntry>(std::move(resolve), std::move(reject),
+                                                      timer, std::move(onDone));
+        transport_->asyncSendRequest(shared_from_this(), timer, std::move(buffer));
+    }
 
-                performImpl(req->request, std::move(req->resolve), std::move(req->reject),
-                            std::move(req->onDone));
-            }
+    void Connection::processRequestQueue()
+    {
+        for (;;)
+        {
+            auto req = requestsQueue.popSafe();
+            if (!req)
+                break;
+
+            performImpl(req->request, std::move(req->resolve), std::move(req->reject),
+                        std::move(req->onDone));
         }
+    }
 
-        void ConnectionPool::init(size_t maxConnectionsPerHost,
-                                  size_t maxResponseSize)
+    void ConnectionPool::init(size_t maxConnectionsPerHost,
+                              size_t maxResponseSize)
+    {
+        this->maxConnectionsPerHost = maxConnectionsPerHost;
+        this->maxResponseSize       = maxResponseSize;
+    }
+
+    std::shared_ptr<Connection>
+    ConnectionPool::pickConnection(const std::string& domain)
+    {
+        Connections pool;
+
         {
-            this->maxConnectionsPerHost = maxConnectionsPerHost;
-            this->maxResponseSize       = maxResponseSize;
-        }
-
-        std::shared_ptr<Connection>
-        ConnectionPool::pickConnection(const std::string& domain)
-        {
-            Connections pool;
-
-            {
-                Guard guard(connsLock);
-                auto poolIt = conns.find(domain);
-                if (poolIt == std::end(conns))
-                {
-                    Connections connections;
-                    for (size_t i = 0; i < maxConnectionsPerHost; ++i)
-                    {
-                        connections.push_back(std::make_shared<Connection>(maxResponseSize));
-                    }
-
-                    poolIt = conns.insert(std::make_pair(domain, std::move(connections))).first;
-                }
-                pool = poolIt->second;
-            }
-
-            for (auto& conn : pool)
-            {
-                if (conn->tryUse())
-                {
-                    return conn;
-                }
-            }
-
-            return nullptr;
-        }
-
-        void ConnectionPool::releaseConnection(
-            const std::shared_ptr<Connection>& connection)
-        {
-            connection->setAsIdle();
-        }
-
-        size_t ConnectionPool::usedConnections(const std::string& domain) const
-        {
-            Connections pool;
-            {
-                Guard guard(connsLock);
-                auto it = conns.find(domain);
-                if (it == std::end(conns))
-                {
-                    return 0;
-                }
-                pool = it->second;
-            }
-
-            return std::count_if(pool.begin(), pool.end(),
-                                 [](const std::shared_ptr<Connection>& conn) {
-                                     return conn->isConnected();
-                                 });
-        }
-
-        size_t ConnectionPool::idleConnections(const std::string& domain) const
-        {
-            Connections pool;
-            {
-                Guard guard(connsLock);
-                auto it = conns.find(domain);
-                if (it == std::end(conns))
-                {
-                    return 0;
-                }
-                pool = it->second;
-            }
-
-            return std::count_if(
-                pool.begin(), pool.end(),
-                [](const std::shared_ptr<Connection>& conn) { return conn->isIdle(); });
-        }
-
-        size_t ConnectionPool::availableConnections(const std::string& /*domain*/) const
-        {
-            return 0;
-        }
-
-        void ConnectionPool::closeIdleConnections(const std::string& /*domain*/)
-        {
-        }
-
-        void ConnectionPool::shutdown()
-        {
-            // close all connections
             Guard guard(connsLock);
-            for (auto& it : conns)
+            auto poolIt = conns.find(domain);
+            if (poolIt == std::end(conns))
             {
-                for (auto& conn : it.second)
+                Connections connections;
+                for (size_t i = 0; i < maxConnectionsPerHost; ++i)
                 {
-                    if (conn->isConnected())
-                    {
-                        conn->close();
-                    }
+                    connections.push_back(std::make_shared<Connection>(maxResponseSize));
                 }
+
+                poolIt = conns.insert(std::make_pair(domain, std::move(connections))).first;
+            }
+            pool = poolIt->second;
+        }
+
+        for (auto& conn : pool)
+        {
+            if (conn->tryUse())
+            {
+                return conn;
             }
         }
 
-        RequestBuilder& RequestBuilder::method(Method method)
+        return nullptr;
+    }
+
+    void ConnectionPool::releaseConnection(
+        const std::shared_ptr<Connection>& connection)
+    {
+        connection->setAsIdle();
+    }
+
+    size_t ConnectionPool::usedConnections(const std::string& domain) const
+    {
+        Connections pool;
         {
-            request_.method_ = method;
-            return *this;
-        }
-
-        RequestBuilder& RequestBuilder::resource(const std::string& val)
-        {
-            request_.resource_ = val;
-            return *this;
-        }
-
-        RequestBuilder& RequestBuilder::params(const Uri::Query& query)
-        {
-            request_.query_ = query;
-            return *this;
-        }
-
-        RequestBuilder&
-        RequestBuilder::header(const std::shared_ptr<Header::Header>& header)
-        {
-            request_.headers_.add(header);
-            return *this;
-        }
-
-        RequestBuilder& RequestBuilder::cookie(const Cookie& cookie)
-        {
-            request_.cookies_.add(cookie);
-            return *this;
-        }
-
-        RequestBuilder& RequestBuilder::body(const std::string& val)
-        {
-            request_.body_ = val;
-            return *this;
-        }
-
-        RequestBuilder& RequestBuilder::body(std::string&& val)
-        {
-            request_.body_ = std::move(val);
-            return *this;
-        }
-
-        RequestBuilder& RequestBuilder::timeout(std::chrono::milliseconds val)
-        {
-            request_.timeout_ = val;
-            return *this;
-        }
-
-        Async::Promise<Response> RequestBuilder::send()
-        {
-            return client_->doRequest(request_);
-        }
-
-        Client::Options& Client::Options::threads(int val)
-        {
-            threads_ = val;
-            return *this;
-        }
-
-        Client::Options& Client::Options::keepAlive(bool val)
-        {
-            keepAlive_ = val;
-            return *this;
-        }
-
-        Client::Options& Client::Options::maxConnectionsPerHost(int val)
-        {
-            maxConnectionsPerHost_ = val;
-            return *this;
-        }
-
-        Client::Options& Client::Options::maxResponseSize(size_t val)
-        {
-            maxResponseSize_ = val;
-            return *this;
-        }
-
-        Client::Client()
-            : reactor_(Aio::Reactor::create())
-            , pool()
-            , transportKey()
-            , ioIndex(0)
-            , queuesLock()
-            , requestsQueues()
-            , stopProcessPequestsQueues(false)
-        { }
-
-        Client::~Client()
-        {
-            assert(stopProcessPequestsQueues == true && "You must explicitly call shutdown method of Client object");
-        }
-
-        Client::Options Client::options() { return Client::Options(); }
-
-        void Client::init(const Client::Options& options)
-        {
-            pool.init(options.maxConnectionsPerHost_, options.maxResponseSize_);
-            reactor_->init(Aio::AsyncContext(options.threads_));
-            transportKey = reactor_->addHandler(std::make_shared<Transport>());
-            reactor_->run();
-        }
-
-        void Client::shutdown()
-        {
-            reactor_->shutdown();
-            pool.shutdown();
-            Guard guard(queuesLock);
-            stopProcessPequestsQueues = true;
-        }
-
-        RequestBuilder Client::get(const std::string& resource)
-        {
-            return prepareRequest(resource, Http::Method::Get);
-        }
-
-        RequestBuilder Client::post(const std::string& resource)
-        {
-            return prepareRequest(resource, Http::Method::Post);
-        }
-
-        RequestBuilder Client::put(const std::string& resource)
-        {
-            return prepareRequest(resource, Http::Method::Put);
-        }
-
-        RequestBuilder Client::patch(const std::string& resource)
-        {
-            return prepareRequest(resource, Http::Method::Patch);
-        }
-
-        RequestBuilder Client::del(const std::string& resource)
-        {
-            return prepareRequest(resource, Http::Method::Delete);
-        }
-
-        RequestBuilder Client::prepareRequest(const std::string& resource,
-                                              Http::Method method)
-        {
-            RequestBuilder builder(this);
-            builder.resource(resource).method(method);
-
-            return builder;
-        }
-
-        Async::Promise<Response> Client::doRequest(Http::Request request)
-        {
-            // request.headers_.add<Header::Connection>(ConnectionControl::KeepAlive);
-            request.headers().remove<Header::UserAgent>();
-            auto resourceData = request.resource();
-
-            auto resource = splitUrl(resourceData);
-            auto conn     = pool.pickConnection(std::string(resource.first));
-
-            if (conn == nullptr)
+            Guard guard(connsLock);
+            auto it = conns.find(domain);
+            if (it == std::end(conns))
             {
-                return Async::Promise<Response>([this, resource = std::move(resource),
-                                                 request](Async::Resolver& resolve,
-                                                          Async::Rejection& reject) {
-                    Guard guard(queuesLock);
-
-                    auto data = std::make_shared<Connection::RequestData>(
-                        std::move(resolve), std::move(reject), std::move(request), nullptr);
-                    auto& queue = requestsQueues[std::string(resource.first)];
-                    if (!queue.enqueue(data))
-                        data->reject(std::runtime_error("Queue is full"));
-                });
+                return 0;
             }
-            else
+            pool = it->second;
+        }
+
+        return std::count_if(pool.begin(), pool.end(),
+                             [](const std::shared_ptr<Connection>& conn) {
+                                 return conn->isConnected();
+                             });
+    }
+
+    size_t ConnectionPool::idleConnections(const std::string& domain) const
+    {
+        Connections pool;
+        {
+            Guard guard(connsLock);
+            auto it = conns.find(domain);
+            if (it == std::end(conns))
             {
+                return 0;
+            }
+            pool = it->second;
+        }
 
-                if (!conn->hasTransport())
+        return std::count_if(
+            pool.begin(), pool.end(),
+            [](const std::shared_ptr<Connection>& conn) { return conn->isIdle(); });
+    }
+
+    size_t ConnectionPool::availableConnections(const std::string& /*domain*/) const
+    {
+        return 0;
+    }
+
+    void ConnectionPool::closeIdleConnections(const std::string& /*domain*/)
+    {
+    }
+
+    void ConnectionPool::shutdown()
+    {
+        // close all connections
+        Guard guard(connsLock);
+        for (auto& it : conns)
+        {
+            for (auto& conn : it.second)
+            {
+                if (conn->isConnected())
                 {
-                    auto transports = reactor_->handlers(transportKey);
-                    auto index      = ioIndex.fetch_add(1) % transports.size();
-
-                    auto transport = std::static_pointer_cast<Transport>(transports[index]);
-                    conn->associateTransport(transport);
+                    conn->close();
                 }
+            }
+        }
+    }
 
-                if (!conn->isConnected())
-                {
-                    std::weak_ptr<Connection> weakConn = conn;
-                    auto res                           = conn->asyncPerform(request, [this, weakConn]() {
-                        auto conn = weakConn.lock();
-                        if (conn)
-                        {
-                            pool.releaseConnection(conn);
-                            processRequestQueue();
-                        }
-                    });
-                    conn->connect(helpers::httpAddr(resource.first));
-                    return res;
-                }
+    RequestBuilder& RequestBuilder::method(Method method)
+    {
+        request_.method_ = method;
+        return *this;
+    }
 
+    RequestBuilder& RequestBuilder::resource(const std::string& val)
+    {
+        request_.resource_ = val;
+        return *this;
+    }
+
+    RequestBuilder& RequestBuilder::params(const Uri::Query& query)
+    {
+        request_.query_ = query;
+        return *this;
+    }
+
+    RequestBuilder&
+    RequestBuilder::header(const std::shared_ptr<Header::Header>& header)
+    {
+        request_.headers_.add(header);
+        return *this;
+    }
+
+    RequestBuilder& RequestBuilder::cookie(const Cookie& cookie)
+    {
+        request_.cookies_.add(cookie);
+        return *this;
+    }
+
+    RequestBuilder& RequestBuilder::body(const std::string& val)
+    {
+        request_.body_ = val;
+        return *this;
+    }
+
+    RequestBuilder& RequestBuilder::body(std::string&& val)
+    {
+        request_.body_ = std::move(val);
+        return *this;
+    }
+
+    RequestBuilder& RequestBuilder::timeout(std::chrono::milliseconds val)
+    {
+        request_.timeout_ = val;
+        return *this;
+    }
+
+    Async::Promise<Response> RequestBuilder::send()
+    {
+        return client_->doRequest(request_);
+    }
+
+    Client::Options& Client::Options::threads(int val)
+    {
+        threads_ = val;
+        return *this;
+    }
+
+    Client::Options& Client::Options::keepAlive(bool val)
+    {
+        keepAlive_ = val;
+        return *this;
+    }
+
+    Client::Options& Client::Options::maxConnectionsPerHost(int val)
+    {
+        maxConnectionsPerHost_ = val;
+        return *this;
+    }
+
+    Client::Options& Client::Options::maxResponseSize(size_t val)
+    {
+        maxResponseSize_ = val;
+        return *this;
+    }
+
+    Client::Client()
+        : reactor_(Aio::Reactor::create())
+        , pool()
+        , transportKey()
+        , ioIndex(0)
+        , queuesLock()
+        , requestsQueues()
+        , stopProcessPequestsQueues(false)
+    { }
+
+    Client::~Client()
+    {
+        assert(stopProcessPequestsQueues == true && "You must explicitly call shutdown method of Client object");
+    }
+
+    Client::Options Client::options() { return Client::Options(); }
+
+    void Client::init(const Client::Options& options)
+    {
+        pool.init(options.maxConnectionsPerHost_, options.maxResponseSize_);
+        reactor_->init(Aio::AsyncContext(options.threads_));
+        transportKey = reactor_->addHandler(std::make_shared<Transport>());
+        reactor_->run();
+    }
+
+    void Client::shutdown()
+    {
+        reactor_->shutdown();
+        pool.shutdown();
+        Guard guard(queuesLock);
+        stopProcessPequestsQueues = true;
+    }
+
+    RequestBuilder Client::get(const std::string& resource)
+    {
+        return prepareRequest(resource, Http::Method::Get);
+    }
+
+    RequestBuilder Client::post(const std::string& resource)
+    {
+        return prepareRequest(resource, Http::Method::Post);
+    }
+
+    RequestBuilder Client::put(const std::string& resource)
+    {
+        return prepareRequest(resource, Http::Method::Put);
+    }
+
+    RequestBuilder Client::patch(const std::string& resource)
+    {
+        return prepareRequest(resource, Http::Method::Patch);
+    }
+
+    RequestBuilder Client::del(const std::string& resource)
+    {
+        return prepareRequest(resource, Http::Method::Delete);
+    }
+
+    RequestBuilder Client::prepareRequest(const std::string& resource,
+                                          Http::Method method)
+    {
+        RequestBuilder builder(this);
+        builder.resource(resource).method(method);
+
+        return builder;
+    }
+
+    Async::Promise<Response> Client::doRequest(Http::Request request)
+    {
+        // request.headers_.add<Header::Connection>(ConnectionControl::KeepAlive);
+        request.headers().remove<Header::UserAgent>();
+        auto resourceData = request.resource();
+
+        auto resource = splitUrl(resourceData);
+        auto conn     = pool.pickConnection(std::string(resource.first));
+
+        if (conn == nullptr)
+        {
+            return Async::Promise<Response>([this, resource = std::move(resource),
+                                             request](Async::Resolver& resolve,
+                                                      Async::Rejection& reject) {
+                Guard guard(queuesLock);
+
+                auto data = std::make_shared<Connection::RequestData>(
+                    std::move(resolve), std::move(reject), std::move(request), nullptr);
+                auto& queue = requestsQueues[std::string(resource.first)];
+                if (!queue.enqueue(data))
+                    data->reject(std::runtime_error("Queue is full"));
+            });
+        }
+        else
+        {
+
+            if (!conn->hasTransport())
+            {
+                auto transports = reactor_->handlers(transportKey);
+                auto index      = ioIndex.fetch_add(1) % transports.size();
+
+                auto transport = std::static_pointer_cast<Transport>(transports[index]);
+                conn->associateTransport(transport);
+            }
+
+            if (!conn->isConnected())
+            {
                 std::weak_ptr<Connection> weakConn = conn;
-                return conn->perform(request, [this, weakConn]() {
+                auto res                           = conn->asyncPerform(request, [this, weakConn]() {
                     auto conn = weakConn.lock();
                     if (conn)
                     {
@@ -1083,41 +1066,53 @@ namespace Pistache
                         processRequestQueue();
                     }
                 });
+                conn->connect(helpers::httpAddr(resource.first));
+                return res;
             }
-        }
 
-        void Client::processRequestQueue()
-        {
-            Guard guard(queuesLock);
-
-            if (stopProcessPequestsQueues)
-                return;
-
-            for (auto& queues : requestsQueues)
-            {
-                for (;;)
+            std::weak_ptr<Connection> weakConn = conn;
+            return conn->perform(request, [this, weakConn]() {
+                auto conn = weakConn.lock();
+                if (conn)
                 {
-                    const auto& domain = queues.first;
-                    auto conn          = pool.pickConnection(domain);
-                    if (!conn)
-                        break;
-
-                    auto& queue = queues.second;
-                    std::shared_ptr<Connection::RequestData> data;
-                    if (!queue.dequeue(data))
-                    {
-                        pool.releaseConnection(conn);
-                        break;
-                    }
-
-                    conn->performImpl(data->request, std::move(data->resolve),
-                                      std::move(data->reject), [this, conn]() {
-                                          pool.releaseConnection(conn);
-                                          processRequestQueue();
-                                      });
+                    pool.releaseConnection(conn);
+                    processRequestQueue();
                 }
+            });
+        }
+    }
+
+    void Client::processRequestQueue()
+    {
+        Guard guard(queuesLock);
+
+        if (stopProcessPequestsQueues)
+            return;
+
+        for (auto& queues : requestsQueues)
+        {
+            for (;;)
+            {
+                const auto& domain = queues.first;
+                auto conn          = pool.pickConnection(domain);
+                if (!conn)
+                    break;
+
+                auto& queue = queues.second;
+                std::shared_ptr<Connection::RequestData> data;
+                if (!queue.dequeue(data))
+                {
+                    pool.releaseConnection(conn);
+                    break;
+                }
+
+                conn->performImpl(data->request, std::move(data->resolve),
+                                  std::move(data->reject), [this, conn]() {
+                                      pool.releaseConnection(conn);
+                                      processRequestQueue();
+                                  });
             }
         }
+    }
 
-    } // namespace Http
-} // namespace Pistache
+} // namespace Pistache::Http

--- a/tests/async_test.cc
+++ b/tests/async_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <pistache/async.h>
 #include <pistache/common.h>

--- a/tests/cookie_test.cc
+++ b/tests/cookie_test.cc
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
-#include <pistache/cookie.h>
 #include <date/date.h>
+#include <pistache/cookie.h>
 
 using namespace Pistache;
 using namespace Pistache::Http;

--- a/tests/cookie_test_2.cc
+++ b/tests/cookie_test_2.cc
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
-#include <pistache/cookie.h>
 #include <date/date.h>
+#include <pistache/cookie.h>
 
 using namespace Pistache;
 using namespace Pistache::Http;

--- a/tests/cookie_test_3.cc
+++ b/tests/cookie_test_3.cc
@@ -10,7 +10,7 @@
 #include <pistache/endpoint.h>
 #include <pistache/http.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <chrono>
 #include <string>

--- a/tests/endpoint_initialization_test.cc
+++ b/tests/endpoint_initialization_test.cc
@@ -7,7 +7,7 @@
 #include <pistache/endpoint.h>
 #include <pistache/router.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 using namespace Pistache;
 

--- a/tests/headers_test.cc
+++ b/tests/headers_test.cc
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <pistache/http.h>
 #include <date/date.h>
+#include <pistache/http.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <algorithm>
 #include <chrono>

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -8,7 +8,7 @@
 #include <pistache/endpoint.h>
 #include <pistache/http.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <atomic>
 #include <chrono>

--- a/tests/http_parsing_test.cc
+++ b/tests/http_parsing_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <pistache/http.h>
 #include <pistache/stream.h>
 

--- a/tests/http_server_test.cc
+++ b/tests/http_server_test.cc
@@ -11,7 +11,7 @@
 #include <pistache/http.h>
 #include <pistache/peer.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <chrono>
 #include <condition_variable>

--- a/tests/http_uri_test.cc
+++ b/tests/http_uri_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <pistache/http.h>
 
 using namespace Pistache;

--- a/tests/https_server_test.cc
+++ b/tests/https_server_test.cc
@@ -10,7 +10,7 @@
 #include <pistache/endpoint.h>
 #include <pistache/http.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <curl/curl.h>
 

--- a/tests/listener_test.cc
+++ b/tests/listener_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <arpa/inet.h>
 #include <errno.h>

--- a/tests/log_api_test.cc
+++ b/tests/log_api_test.cc
@@ -9,7 +9,7 @@
 
 #include <pistache/log.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 using namespace Pistache;
 

--- a/tests/mailbox_test.cc
+++ b/tests/mailbox_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <pistache/mailbox.h>
 
 struct Data

--- a/tests/mime_test.cc
+++ b/tests/mime_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <pistache/http.h>
 #include <pistache/mime.h>

--- a/tests/net_test.cc
+++ b/tests/net_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <pistache/net.h>
 

--- a/tests/reactor_test.cc
+++ b/tests/reactor_test.cc
@@ -7,7 +7,7 @@
 #include <pistache/mailbox.h>
 #include <pistache/reactor.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <chrono>
 #include <iostream>

--- a/tests/request_size_test.cc
+++ b/tests/request_size_test.cc
@@ -10,7 +10,7 @@
 #include <pistache/endpoint.h>
 #include <pistache/http.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <chrono>
 #include <memory>

--- a/tests/rest_server_test.cc
+++ b/tests/rest_server_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <pistache/endpoint.h>
 #include <pistache/http.h>

--- a/tests/router_test.cc
+++ b/tests/router_test.cc
@@ -10,8 +10,8 @@
    Unit tests for the rest router
 */
 
-#include "gtest/gtest.h"
 #include <algorithm>
+#include <gtest/gtest.h>
 
 #include <pistache/common.h>
 #include <pistache/endpoint.h>

--- a/tests/stream_test.cc
+++ b/tests/stream_test.cc
@@ -6,7 +6,7 @@
 
 #include <pistache/stream.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <climits>
 #include <cstdio>

--- a/tests/streaming_test.cc
+++ b/tests/streaming_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <pistache/client.h>
 #include <pistache/description.h>

--- a/tests/string_logger_test.cc
+++ b/tests/string_logger_test.cc
@@ -9,7 +9,7 @@
 
 #include <pistache/string_logger.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 using namespace Pistache;
 

--- a/tests/threadname_test.cc
+++ b/tests/threadname_test.cc
@@ -10,7 +10,7 @@
 #include <pistache/endpoint.h>
 #include <pistache/http.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <chrono>
 #include <fstream>

--- a/tests/typeid_test.cc
+++ b/tests/typeid_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <pistache/typeid.h>
 
 using namespace Pistache;

--- a/tests/view_test.cc
+++ b/tests/view_test.cc
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <pistache/view.h>
 
 using namespace Pistache;


### PR DESCRIPTION
Nested namespaces in serializer/rapidjson.h and client.cc, reformat all files, add .clang-format-ignore ignoring subprojects, use angled brackets when including gtest.h.

Huge diff because of whitespace changes. If you want to take a look at the diff in GitHub remember to ignore whitespace changes appending [`?w=1`](https://github.com/pistacheio/pistache/pull/955/files?w=1) to the URL.