### PR TITLE
include/pistache/typeid.h: include stddef.h

### DIFF
--- a/include/pistache/typeid.h
+++ b/include/pistache/typeid.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <functional>
 
 namespace Pistache


### PR DESCRIPTION
Include `stddef.h` to avoid the following build failure with gcc 11:

```
In file included from /tmp/instance-3/output-1/build/pistache-f2f5a50fbfb5b8ef6cf1d3d2a9d442a8270e375d/src/../include/pistache/async.h:10,
                 from /tmp/instance-3/output-1/build/pistache-f2f5a50fbfb5b8ef6cf1d3d2a9d442a8270e375d/src/../include/pistache/client.h:9,
                 from /tmp/instance-3/output-1/build/pistache-f2f5a50fbfb5b8ef6cf1d3d2a9d442a8270e375d/src/client/client.cc:7:
/tmp/instance-3/output-1/build/pistache-f2f5a50fbfb5b8ef6cf1d3d2a9d442a8270e375d/src/../include/pistache/typeid.h:26:12: error: expected type-specifier before 'size_t'
   26 |   operator size_t() const { return reinterpret_cast<size_t>(id_); }
      |            ^~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/2443559df8c2357476e4cbdbebb08280cbb80a3b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>