### PR TITLE
also check for linking with libatomic

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,11 +49,11 @@ int main() {
 	return ++x;
 }
 '''
-has_working_cxx_atomics = compiler.compiles(cxx_atomics_check_code, name: 'std::atomic')
+has_working_cxx_atomics = compiler.links(cxx_atomics_check_code, name: 'std::atomic')
 if (compiler_id == 'clang' or compiler_id == 'gcc') and not has_working_cxx_atomics
 	libatomic_dep = compiler.find_library('atomic')
 	assert(compiler.has_function('__atomic_fetch_add_4', dependencies: libatomic_dep), 'Host compiler appears to require libatomic, but cannot find it.')
-	has_working_cxx_atomics = compiler.compiles(cxx_atomics_check_code, dependencies: libatomic_dep, name: 'std::atomic with libatomic')
+	has_working_cxx_atomics = compiler.links(cxx_atomics_check_code, dependencies: libatomic_dep, name: 'std::atomic with libatomic')
 	assert(has_working_cxx_atomics, 'Host compiler must support std::atomic')
 	deps_libpistache += libatomic_dep
 endif
@@ -68,11 +68,11 @@ int main() {
 	return 0;
 }
 '''
-has_working_cxx_atomics64 = compiler.compiles(cxx_atomics64_check_code, name: 'std::atomic<uint64_t>')
+has_working_cxx_atomics64 = compiler.links(cxx_atomics64_check_code, name: 'std::atomic<uint64_t>')
 if (compiler_id == 'clang' or compiler_id == 'gcc') and not has_working_cxx_atomics64
 	libatomic_dep = compiler.find_library('atomic')
 	assert(compiler.has_function('__atomic_load_8', dependencies: libatomic_dep), 'Host compiler appears to require libatomic for 64-bit operations, but cannot find it.')
-	has_working_cxx_atomics = compiler.compiles(cxx_atomics64_check_code, dependencies: libatomic_dep, name: 'std::atomic<uint64_t> with libatomic')
+	has_working_cxx_atomics = compiler.links(cxx_atomics64_check_code, dependencies: libatomic_dep, name: 'std::atomic<uint64_t> with libatomic')
 	assert(has_working_cxx_atomics, 'Host compiler must support 64-bit std::atomic')
 	deps_libpistache += libatomic_dep
 endif


### PR DESCRIPTION
On some operating systems (like Raspberry Pi OS) with libatomic installed meson configuration succeeds when it shouldn't. Actually building fails on the linking phase because of missing methods in 32 bit version of libatomic.

Improved meson checks added to avoid confusion (and false hope).