### PR TITLE
build(debian): depend on python3-distutils

### DIFF
--- a/control
+++ b/control
@@ -8,7 +8,8 @@ Priority: optional
 Maintainer: Kip Warner <kip@thevertigo.com>
 Standards-Version: 4.6.0
 Build-Depends: debhelper-compat (= 12),
-               meson (>= 0.50.0)
+               meson (>= 0.50.0),
+               python3-distutils
 Build-Depends-Arch: pkg-config,
                     libssl-dev,
                     rapidjson-dev,


### PR DESCRIPTION
The Meson Debian package should depend on that package itself, but for some reason it doesn't (for details, see https://github.com/mesonbuild/meson/issues/4267#issuecomment-920919273)