### PR TITLE
build(meson): look for howardhinnant-date

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,10 @@ if get_option('b_coverage')
 	add_project_arguments(compiler.get_supported_arguments(['-fstack-protector-all', '--param=ssp-buffer-size=4']), language: 'cpp')
 endif
 
-date_dep = dependency('hinnant-date', fallback: ['hinnant-date', 'date_dep'])
+date_dep = dependency('howardhinnant-date', required: false)
+if not date_dep.found()
+	date_dep = dependency('hinnant-date', fallback: ['hinnant-date', 'date_dep'])
+endif
 deps_libpistache = [
 	dependency('threads'),
 	dependency('RapidJSON', fallback: ['rapidjson', 'rapidjson_dep']),


### PR DESCRIPTION
Since the "date" library has such a general name, it often gets renamed to "hinnant-date", "howardhinnant-date", etc. This change enables Meson to find the library when it is called in either ways. This "new" name is used, for example, in the Debian package.