### PR TITLE
build(debian): use d/watch to download latest HEAD

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,5 @@
-pistache (0.0.002-pistache1) impish; urgency=medium
+pistache (0.0.002-1) UNRELEASED; urgency=low
 
-  * Latest upstream.
+  * Initial release. Closes: #929593
 
- -- Kip Warner <kip@thevertigo.com>  Sun, 27 Dec 2020 16:40:00 -0700
+ -- Kip Warner <kip@thevertigo.com>  Tue, 28 Sep 2021 14:45:20 +0000

--- a/control
+++ b/control
@@ -3,28 +3,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Source: pistache
-Section: libdevel
+Section: libs
 Priority: optional
 Maintainer: Kip Warner <kip@thevertigo.com>
 Standards-Version: 4.6.0
-Build-Depends: debhelper-compat (= 12),
-               meson (>= 0.50.0),
-               python3-distutils
-Build-Depends-Arch: pkg-config,
-                    libssl-dev,
-                    rapidjson-dev,
+Build-Depends: debhelper-compat (= 12), meson (>= 0.50.0), python3-distutils
+Build-Depends-Arch: libcurl4-openssl-dev,
                     libgtest-dev (>= 1.8.0) | googletest (>= 1.8.0),
-                    libcurl4-openssl-dev
+                    libssl-dev,
+                    pkg-config,
+                    rapidjson-dev
 Vcs-Git: https://github.com/pistacheio/pistache.git
-Vcs-browser: https://github.com/pistacheio/pistache
+Vcs-Browser: https://github.com/pistacheio/pistache
 Homepage: http://pistache.io
 Rules-Requires-Root: no
 
 Package: libpistache0
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends},
-         ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: elegant C++ REST framework
  Pistache is a modern and elegant HTTP and REST framework for C++.
  It is entirely written in pure C++17 and provides a clear and pleasant API.
@@ -35,12 +32,13 @@ Description: elegant C++ REST framework
  This package contains the shared library built with TLS support.
 
 Package: libpistache-dev
+Section: libdevel
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends},
-         libpistache0 (= ${binary:Version}),
+Depends: libpistache0 (= ${binary:Version}),
          libssl-dev,
-         rapidjson-dev
+         rapidjson-dev,
+         ${misc:Depends}
 Description: elegant C++ REST framework - development files
  Pistache is a modern and elegant HTTP and REST framework for C++.
  It is entirely written in pure C++17 and provides a clear and pleasant API.

--- a/libpistache-dev.docs
+++ b/libpistache-dev.docs
@@ -1,2 +1,1 @@
 README.md
-LICENSE

--- a/libpistache0.docs
+++ b/libpistache0.docs
@@ -1,2 +1,1 @@
 README.md
-LICENSE

--- a/rules
+++ b/rules
@@ -16,19 +16,6 @@ export DH_BUILD_MAINT_OPTIONS = hardening=+all
 
 export LC_ALL = C.UTF-8
 
-# Should be avoided since debhelper 9
-# https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#variablesrules
-# Including only the necessary variables
-include /usr/share/dpkg/pkg-info.mk
-
-# Directory containing package since may not be called from current working
-#  directory. MAKEFILE_LIST pre-defined by Make and appended each time another
-#  makefile is included, so first one should be debian/rules...
-PACKAGE_DIR = $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
-
-# Source directory...
-SOURCE_DIR  = $(abspath $(PACKAGE_DIR)/../)
-
 # Main packaging script based on debhelper 7 syntax. The % is an implicit
 #  pattern rule that acts as a universal target...
 %:
@@ -42,42 +29,6 @@ override_dh_auto_configure:
 		-DPISTACHE_BUILD_TESTS=true \
 		-DPISTACHE_ENABLE_NETWORK_TESTS=false \
 		-DPISTACHE_BUILD_DOCS=false \
-		-DPISTACHE_USE_SSL=true \
+		-DPISTACHE_USE_SSL=true
 
 #override_dh_auto_test: https://github.com/pistacheio/pistache/blob/f3080e9e4e7ce5d0cb866b5d6320d51205c33ff0/debian/rules#L53-L63
-
-# get-orig-source is deprecated since version 4.1.4 of the Debian Policy
-# Prepare an upstream vanilla distribution tarball as per DPM § 4.9...
-#  http://wiki.debian.org/onlyjob/get-orig-source
-get-orig-source: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.gz $(info I: $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM))
-	@
-
-# Prepare an upstream vanilla distribution tarball...
-# meson dist does not include .github in the source tarball (mesonbuild/meson#8541)
-# so it is necessary to manually add the folder to the archive
-$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.gz:
-	@echo "# Preparing source for $(DEB_SOURCE) v$(DEB_VERSION_UPSTREAM)..."
-	cd $(SOURCE_DIR) \
-	&& cd $(PACKAGE_DIR) \
-	&& meson setup $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM) .. \
-		--buildtype=plain \
-		-DPISTACHE_BUILD_EXAMPLES=true \
-		-DPISTACHE_BUILD_TESTS=true \
-		-DPISTACHE_ENABLE_NETWORK_TESTS=false \
-		-DPISTACHE_BUILD_DOCS=false \
-		-DPISTACHE_USE_SSL=true \
-		--prefix=/usr \
-		--wrap-mode=nodownload \
-	&& meson dist -C $(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM) --formats=gztar \
-	&& cd $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM) \
-	&& mkdir $(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM) \
-	&& cp -r $(SOURCE_DIR)/.github $(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM) \
-	&& gunzip $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)/meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar.gz \
-	&& tar --append --file=$(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)/meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar $(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM)/.github \
-	&& gzip $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)/meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar \
-	&& mv $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)/meson-dist/$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM).tar.gz $(SOURCE_DIR)/../$@
-	@echo "# Cleaning up..."
-	$(RM) -r $(PACKAGE_DIR)/$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM)
-
-# Targets which aren't actual products...
-.PHONY: get-orig-source override_dh_auto_configure# override_dh_auto_test

--- a/watch
+++ b/watch
@@ -1,3 +1,4 @@
 version=4
-opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/pistache-$1\.tar\.gz/ \
-  https://github.com/pistacheio/pistache/releases .*/v?(\d\S*)\.tar\.gz
+opts="mode=git, pgpmode=none, pretty=0.0.002+git%cd.%h" \
+https://github.com/pistacheio/pistache.git \
+HEAD debian uupdate


### PR DESCRIPTION
This allows the use of uscan to get the upstream source, a much more elegant approach.

See https://manpages.debian.org/uscan.1.html#direct_access_to_the_git_repository_(HEAD)

I've also fixed a few Lintian warnings, like including the license with the docs, using the wrong section for the package, not including the ITP bug in the first changelog entry and wrong capitalization of Vcs-Browser. The only major violation left is the use of the "libpistache0" package name even if the SONAME is 0.0. I would suggest removing the minor SOVERSION, as ABI is either compatible or incompatible, there's no "minor" incompatibility. More of this in a separate PR.

This should not be merged yet, as I have to update the autopkgtest CI job.