### PR TITLE
ssl: Enable partial write on SSL context

### DIFF
--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -138,6 +138,7 @@ namespace Pistache::Tcp
                 throw std::runtime_error(err);
             }
 
+            SSL_CTX_set_mode(GetSSLContext(ctx), SSL_MODE_ENABLE_PARTIAL_WRITE);
             return ctx;
         }
 


### PR DESCRIPTION
This patch enables the partial write mode on the SSL server context,
giving us "normal" behavior on non-blocking sockets.

This patch is meant to be a sleep-less alternative to https://github.com/pistacheio/pistache/pull/832,
with the advantage of also fixing a potential issue on file streaming.

Should not break any behavior.

Signed-off-by: Louis Solofrizzo <lsolofrizzo@scaleway.com>