### PR TITLE
fix(ssl): enable ssl mode for moving buffers

### DIFF
--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -139,6 +139,7 @@ namespace Pistache::Tcp
             }
 
             SSL_CTX_set_mode(GetSSLContext(ctx), SSL_MODE_ENABLE_PARTIAL_WRITE);
+            SSL_CTX_set_mode(GetSSLContext(ctx), SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
             return ctx;
         }
 


### PR DESCRIPTION
Due to internals of pistache, a write after a retry may be with a
different address than the original call. By default, OpenSSL doesn't
like that:

    SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER

        Make it possible to retry SSL_write() with changed buffer location
        (the buffer contents must stay the same). This is not the default to
        avoid the misconception that non-blocking SSL_write() behaves like
        non-blocking write().

This should fix any weird behavior on large file / responses (#807)

Signed-off-by: Louis Solofrizzo <lsolofrizzo@scaleway.com>