### PR TITLE
d/watch: remove manual `pretty` option

### DIFF
--- a/watch
+++ b/watch
@@ -1,4 +1,4 @@
 version=4
-opts="mode=git, pgpmode=none, pretty=0.0.002+git%cd.%h" \
+opts="mode=git, pgpmode=none" \
 https://github.com/pistacheio/pistache.git \
 HEAD debian uupdate


### PR DESCRIPTION
This was needed to replace the default `~git$date.$hash` suffix with `+git$date.$hash`, because in Debian `+` is greater than `~`, and it was needed to make the PPA happy. This unfortunately requires the d/watch file to be updated every time the version number is bumped.

Dropping the custom version in d/watch and relying on the default is just better, and will also fix CI.

This must be merged **before** #1010, and if this gets merged #1010 must be merged as well