### PR TITLE
watch: use manual pretty option

### DIFF
--- a/watch
+++ b/watch
@@ -1,4 +1,4 @@
 version=4
-opts="mode=git, pgpmode=none" \
+opts="mode=git, pgpmode=none, pretty=0.0.3+git%cd.%h" \
 https://github.com/pistacheio/pistache.git \
 HEAD debian uupdate


### PR DESCRIPTION
I tried dropping it in cec95bc171675c908ae1140ee1277e44a42109df, but unfortunately until we tag a release we'll have to manually update the watch file.

I'm not sure this will completely fix all CI issues, but merging this would help me debugging it anyway