### PR TITLE
Possible solution for BUG#1007

### DIFF
--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -356,7 +356,8 @@ namespace Pistache::Tcp
         else
         {
 #endif /* PISTACHE_USE_SSL */
-            bytesWritten = ::send(fd, buffer, len, flags);
+            //MSG_NOSIGNAL is used to prevent SIGPIPE on client connection termination
+            bytesWritten = ::send(fd, buffer, len, flags | MSG_NOSIGNAL);
 #ifdef PISTACHE_USE_SSL
         }
 #endif /* PISTACHE_USE_SSL */


### PR DESCRIPTION
I'm also currently facing the issue described in #1007. I added the MSG_NOSIGNAL Flag as proposed by @amang8662. But there was still the problem, how to get the info if the socket is still alive. So I checked on the documentation (https://linux.die.net/man/3/getsockopt). With the function `getsockopt()` you are able to receive the last error of the socket. In case the pipe breaks, the error is returned through this function. So we can check if the stream is still alive by testing the return value. 

I added the function `isOpen()` which returns true if there isn't an error on the socket and false otherwise.

This is my first PR in any open-source project. So I hope for leniency.