### PR TITLE
ci(autopkgtest): use awk to get the upstream version

### DIFF
--- a/.github/workflows/autopkgtest.yaml
+++ b/.github/workflows/autopkgtest.yaml
@@ -76,7 +76,7 @@ jobs:
     - name: Create .orig tarball
       run: |
         repo_name=$(echo ${{ github.repository }} | cut -d / -f 2)
-        debian_version=$(dpkg-parsechangelog --show-field Version | cut -d - -f 1)
+        debian_version=$(dpkg-parsechangelog --show-field Version | awk -F - 'sub(FS $NF,x)')
         cd ..
         tar --exclude-vcs --exclude=debian -cvzf pistache_"$debian_version".orig.tar.gz "$repo_name"
 


### PR DESCRIPTION
A Debian package version is usually composed like this: `upstream_version+suffix-revision`

The .orig tarball needs to only have the upstream_version part plus the suffix, so I previously used `cut -d - -f 1` to split the Debian version at the first hyphen and obtain the upstream version.

This works in our case, because:

    $ echo 0.0.003-1 | cut -d - -f 1
    0.0.003

but it is perfectly legal to have an upstream version containing hyphens itself:

    $ echo 0.0.4-beta-1 | cut -d - -f 1
    0.0.4

and this results in a wrong upstream version, as -beta is cut out.

A way to avoid this is to use awk instead of cut. I originally preferred cut as it is a simpler tool and I don't know awk at all, but unfortunately it is too simple.

Hyphens in the upstream version are now handled correctly:

    $ echo 0.0.4-beta-1 | awk -F - 'sub(FS $NF,x)'
    0.0.4-beta

To be honest I don't know _how_ this works, so if somebody would like to explain it to me I would really appreciate it. The awk manpage is quite complex :/