### PR TITLE
ci: build on multiple Linux distributions

### DIFF
--- a/.github/workflows/autopkgtest.yaml
+++ b/.github/workflows/autopkgtest.yaml
@@ -24,54 +24,23 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ amd64, arm64, armhf, i386, ppc64el ] # , s390x
+    container:
+      image: debian:testing
 
     steps:
+    - name: Install dependencies
+      run: |
+        apt -y update
+        apt -y install autopkgtest dpkg-dev --no-install-recommends
+
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Checkout Debian data
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: debian
         path: debian
-
-    # The Debian repository is needed by autopkgtest-build-qemu when building
-    # for foreign architectures, since the tool tries to install
-    # linux-image-${{ matrix.arch }}, that is unavailable on Ubuntu; adding
-    # the Debian Testing repo and lowering its priority solves the issue
-    # while not risking to break the system mixing Debian and Ubuntu pkgs.
-    # The pgp key required to use the repository is downloaded through the
-    # debain-archive-keyring package, and instead of using the deprecated
-    # apt-key utility to add the keyring to the trusted ones I use the
-    # Signed-By option (deb822 source format), as recommended in the Debian
-    # wiki (https://wiki.debian.org/DebianRepository/UseThirdParty).
-    # Node.js stuff is purged since it is not needed and for whatever reason
-    # causes a warning to be generated when building autopkgtest.
-    # Also qemu-system-gui is holded to prevent installation since it is not
-    # needed, and both vmdb2 and qemu-user-static are installed from testing
-    # because the version available in Ubuntu does not work; the old vmdb2
-    # causes image generation failures for all architectures, qemu-user-static
-    # only for arm64, but causes autopkgtest to fail for armhf and ppc64el.
-    # The debian-archive.trafficmanager.net mirror is used since it is the
-    # Azure mirror, and GitHub Actions run on that network.
-    # The --no-install-recommends apt option is important, as installing
-    # recommended packages causes autopkgtest to fail for arm64 and armhf;
-    # I don't know why, I don't know how, I only know that it tooks hours to
-    # figure it out.
-    - name: Install dependencies
-      run: |
-        sudo apt install debian-archive-keyring
-        printf 'Enabled: yes\nTypes: deb\nURIs: http://debian-archive.trafficmanager.net/debian/\nSuites: testing\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n' | sudo tee /etc/apt/sources.list.d/debian.sources
-        printf 'Package: *\nPin: release o=Debian,a=testing\nPin-Priority: 400\n' | sudo tee /etc/apt/preferences.d/99debian-testing
-        sudo apt update
-        sudo apt autopurge '*yarn*' '*npm*' '*node*'
-        sudo rm -rf /usr/local/lib/node_modules
-        sudo apt --assume-yes install autopkgtest/testing genisoimage qemu-system vmdb2/testing dpkg-dev --no-install-recommends qemu-user-static/testing qemu-efi-aarch64 qemu-efi-arm ovmf ovmf-ia32 && sudo apt-mark auto qemu-user-static qemu-efi-aarch64 qemu-efi-arm ovmf ovmf-ia32
 
     - name: Create .orig tarball
       run: |
@@ -83,34 +52,10 @@ jobs:
     - name: Build Debian package source
       run: dpkg-source --build .
 
-    - name: Build image
-      run: sudo autopkgtest-build-qemu --architecture ${{ matrix.arch }} --size 12G testing $HOME/autopkgtest-testing.img
-
-    # The increased timeout is needed because the CI can be too slow to boot
-    # the image. --dpkg-architecture is needed because autopkgtest-virt-qemu
-    # defaults to the host arch instead of reading it from the image.
-    # The ram size is set to 3072 MB because the default 1 GiB is not enough
-    # to build Pistache, the amount must be less than 4 GiB otherwise the i386
-    # image won't boot, ppc64el requires it to be aligned to 256 MiB and an
-    # amout not convertible to a GiB integer causes arm64 to fail, while extra
-    # CPU cores can't be used as they can cause arm runs to fail with the error
-    # below. Instead of explicitly calling autopkgtest-virt-qemu it should be
-    # enough to just write qemu.
-    # Currently this sometimes fails on i386 with
-    #   <VirtSubproc>: failure: timed out waiting for 'login prompt on serial
-    #     console'
-    # on arm64 and armhf with
-    #   host login: <VirtSubproc>: failure: The VM does not start a root shell
-    #     on ttyS1 or hvc1 already. The only other supported login mechanism is
-    #     through --user and -*** the guest ttyS0
-    # on almost all architectures with
-    #   ERROR: testbed failure: sent `auxverb_debug_fail', got `timeout',
-    #     expected `ok...'
-
     - name: Run autopkgtest
       run: |
         exit_code=0
-        autopkgtest ../pistache_*.dsc -- qemu --dpkg-architecture=${{ matrix.arch }} --timeout-reboot=120 --ram-size=3072 $HOME/autopkgtest-testing.img || exit_code=$?
+        autopkgtest ../pistache_*.dsc -- null || exit_code=$?
         if [ $exit_code -eq 16 ]
         then
           echo "::warning::autopkgtest failed, but it's not your fault"

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2022 Andrea Pappacoda
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: linux
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'debian:stable', 'debian:testing', 'registry.access.redhat.com/ubi8/ubi-minimal', 'registry.access.redhat.com/ubi9/ubi-minimal' ]
+        compiler: [ 'gcc', 'clang' ]
+        sanitizer: [ 'address', 'undefined', 'none' ] # ThreadSanitizer reports errors
+        exclude:
+          - os: 'registry.access.redhat.com/ubi8/ubi-minimal'
+            sanitizer: 'address'
+          - os: 'registry.access.redhat.com/ubi8/ubi-minimal'
+            sanitizer: 'thread'
+          - os: 'registry.access.redhat.com/ubi8/ubi-minimal'
+            sanitizer: 'undefined'
+          - os: 'registry.access.redhat.com/ubi9/ubi-minimal'
+            sanitizer: 'address'
+          - os: 'registry.access.redhat.com/ubi9/ubi-minimal'
+            sanitizer: 'thread'
+          - os: 'registry.access.redhat.com/ubi9/ubi-minimal'
+            sanitizer: 'undefined'
+
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.os }}
+
+    steps:
+    # llvm-dev is required because it contains LLVMgold.so in Debian 11
+    - name: Install dependencies (Debian)
+      if: contains(matrix.os, 'debian')
+      run: |
+        if [ ${{ matrix.compiler }} = gcc ]; then compiler=g++; else compiler=clang; fi
+        apt -y update
+        apt -y install $compiler meson pkg-config cmake rapidjson-dev libssl-dev libgtest-dev libcurl4-openssl-dev git ca-certificates curl gpg gpgv gpg-agent lcov llvm-dev --no-install-recommends
+
+    - name: Install dependencies (Red Hat)
+      if: contains(matrix.os, 'redhat')
+      run: |
+        if [ ${{ matrix.compiler }} = gcc ]; then compiler=gcc-c++; else compiler=clang; fi
+        microdnf -y install $compiler pkgconf cmake libcurl-devel git python3-pip
+        pip3 install meson ninja
+
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Configure Meson
+      run: |
+        if [ ${{ matrix.compiler }} = gcc ]; then CXX=g++; else CXX=clang++; fi
+        export CXX
+        meson setup build -DPISTACHE_BUILD_TESTS=true --buildtype=debug -Db_coverage=true -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false
+      env:
+        CC: ${{ matrix.compiler }}
+
+    - name: Build
+      run: ninja -C build
+
+    - name: Test
+      run: meson test -C build --verbose
+
+    - name: Coverage
+      if: ${{ !contains(matrix.os, 'redhat') }}
+      run: |
+        mkdir --parents $HOME/.local/bin
+        if [ "${{ matrix.compiler }}" = 'clang' ]; then printf 'llvm-cov gcov "$@"' > $HOME/.local/bin/cov.sh; else printf 'gcov "$@"' > $HOME/.local/bin/cov.sh; fi && chmod +x $HOME/.local/bin/cov.sh
+        lcov --capture --output-file coverage.info --directory . --gcov-tool $HOME/.local/bin/cov.sh --exclude '/usr/*' --exclude "${HOME}"'/.cache/*' --exclude '*/tests/*' --exclude '*/subprojects/*'
+        lcov --list coverage.info
+        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+        curl --silent --remote-name https://uploader.codecov.io/latest/linux/codecov
+        curl --silent --remote-name https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+        curl --silent --remote-name https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+        sha256sum --check codecov.SHA256SUM
+        chmod +x codecov
+        ./codecov

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -8,4 +8,4 @@ for file in $(git diff-index --cached --name-only HEAD | grep -E '\.(cpp|cc|hpp|
     clang-format --dry-run --Werror "$file" >/dev/null 2>&1 || (echo 'Run ninja clang-format before committing' 1>&2 && false)
 done
 
-grep "$(date +%Y%m%d)" version.txt || (echo 'Update the commit date in version.txt before committing' 1>&2 && false)
+grep -q "$(date +%Y%m%d)" version.txt || (echo 'Update the commit date in version.txt before committing' 1>&2 && false)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ SPDX-License-Identifier: Apache-2.0
 
 [![N|Solid](pistache.io/static/img/logo.png)](https://www.github.com/pistacheio/pistache)
 
+[![linux](https://github.com/pistacheio/pistache/actions/workflows/linux.yaml/badge.svg)](https://github.com/pistacheio/pistache/actions/workflows/linux.yaml)
 [![autopkgtest](https://github.com/pistacheio/pistache/actions/workflows/autopkgtest.yaml/badge.svg)](https://github.com/pistacheio/pistache/actions/workflows/autopkgtest.yaml)
+[![codecov](https://codecov.io/gh/pistacheio/pistache/branch/master/graph/badge.svg)](https://codecov.io/gh/pistacheio/pistache)
 [![REUSE status](https://api.reuse.software/badge/github.com/pistacheio/pistache)](https://api.reuse.software/info/github.com/pistacheio/pistache)
 
 Pistache is a modern and elegant HTTP and REST framework for C++. It is entirely written in pure-C++17[*](#linux-only) and provides a clear and pleasant API.


### PR DESCRIPTION
This new CI job builds and tests Pistache on different Linux distros, with different compilers, and under different sanitizers, and also re-adds Codecov coverage integration back.

Currently, Pistache is tested on Debian Stable, Debian Testing and Red Hat Enterprise Linux 8, and the code is built with GCC and Clang. Sanitizers are only used on Debian, because as far as I'm aware RHEL doesn't ship the various sanitizers in its base images.

ThreadSanitizer is also disabled for now, as it reports a lot of data races in some tests. Some of the bugs are in the unit tests themselves, but I haven't yet looked into solving them. @dennisjenkins75 I seem to remember that you opened a meta-issue about dace conditions in Pistache but I haven't found it.

~I'll add RHEL 9 as soon as Red Hat publishes the image on [Docker Hub](https://hub.docker.com/r/redhat/ubi9-minimal)~ added using Red Hat's own registry

It would be nice to add something like [Gentoo](https://hub.docker.com/r/gentoo/stage3) too; @dennisjenkins75 you use/used Gentoo, right? Would you be able to help?

~I've also fixed a bug in the [`streaming_test`](https://github.com/pistacheio/pistache/pull/1070/commits/f5aeaa87795e45e8802e134adf9554f91b30aea1) test that caused lock ups on old distros (@kiplingw this means that PPA builds for Ubuntu 20.10 and older should be fixed as well)~ pushed as 8ce07256dc220cbf96b3fd6f5991a3c68fd54aba

Lastly, I ~removed~ [reduced the scope of the autopkgtest](https://github.com/pistacheio/pistache/pull/1070/commits/cc2025c525a55a688dc010bbb025928432f56b15) job; you can find my rationale in the commit message.