### PR TITLE
Remove CNAME file from gh-pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-pistache.io


### PR DESCRIPTION
This should make it possible to reach the Pistache website at [pistacheio.github.io/pistache](https://pistacheio.github.io/pistache)