### PR TITLE
docs: use pistacheio.github.io/pistache/

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Pistache is a modern and elegant HTTP and REST framework for C++. It is entirely
 
 ## Documentation
 
-We are still looking for a volunteer to document fully the API. In the mean time, partial documentation is available at [pistache.io](http://pistache.io). If you are interested in helping with this, please open an issue ticket.
+We are still looking for a volunteer to document fully the API. In the mean time, partial documentation is available at [pistacheio.github.io/pistache/](https://pistacheio.github.io/pistache/). If you are interested in helping with this, please open an issue ticket.
 
 A comparison of Pistache to other C++ RESTful APIs was created by guteksan and is available [here](https://github.com/guteksan/REST-CPP-benchmark).
 

--- a/pistache.io/docusaurus.config.js
+++ b/pistache.io/docusaurus.config.js
@@ -5,8 +5,8 @@
 module.exports = {
   title: 'Pistache',
   tagline: 'An elegant C++ REST framework.',
-  url: 'https://pistache.io',
-  baseUrl: '/',
+  url: 'https://pistacheio.github.io',
+  baseUrl: '/pistache/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/logo.png',

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,7 +55,7 @@ import('pkgconfig').generate(
 	libpistache,
 	name: 'Pistache',
 	description: 'An elegant C++ REST framework',
-	url: 'http://pistache.io',
+	url: 'https://pistacheio.github.io/pistache/',
 	version: '@0@-git@1@'.format(version_str, version_git_date),
 	filebase: 'libpistache'
 )


### PR DESCRIPTION
The pistache.io domain has been renewed by somebody outside of the Pistache organization, and there's not much we can do about it...