### PR TITLE
CMake subproject fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,6 @@ cmake_minimum_required (VERSION 3.11)
 
 set(CMAKE_BUILD_TYPE_INIT Release)
 
-# CMAKE Pin cxx compiler to CXX17
-set(CMAKE_CXX_STANDARD 17)
-
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 file(READ "version.txt" VERSION_FILE_RAW)
 string(STRIP "${VERSION_FILE_RAW}" VERSION_FILE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,5 +93,8 @@ add_custom_target(format
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-install(CODE "message(FATAL_ERROR \"Please use Meson to install Pistache.
+# CMake 3.21 defines this automatically
+if (PROJECT_IS_TOP_LEVEL OR CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    install(CODE "message(FATAL_ERROR \"Please use Meson to install Pistache.
 See the README for details: https://github.com/pistacheio/pistache#building-from-source\")")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCE_FILES
 
 add_library(pistache OBJECT ${SOURCE_FILES})
 set_target_properties(pistache PROPERTIES POSITION_INDEPENDENT_CODE ${PISTACHE_PIC})
+target_compile_features(pistache PRIVATE cxx_std_17)
 add_definitions(-DONLY_C_LOCALE=1)
 
 set(PISTACHE_INCLUDE


### PR DESCRIPTION
In this PR I've made some minor improvements to the CMake files so that Pistache plays more nicely when it is included as a subproject. See the individual commits for details.