### PR TITLE
ci(autopkgtest): get debian/ from pistacheio/pistache

### DIFF
--- a/.github/workflows/autopkgtest.yaml
+++ b/.github/workflows/autopkgtest.yaml
@@ -39,6 +39,7 @@ jobs:
     - name: Checkout Debian data
       uses: actions/checkout@v3
       with:
+        repository: pistacheio/pistache
         ref: debian
         path: debian
 


### PR DESCRIPTION
So that contributors don't have to keep in sync both the `master` and `debian` branches.