### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,21 @@ Some other Meson options:
 | PISTACHE_BUILD_EXAMPLES       | False   | Build all of the example apps                  |
 | PISTACHE_BUILD_DOCS           | False   | Build Doxygen docs                             |
 
+
+## Installing pistache using vcpkg
+
+You can download and install pistache using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install pistache
+```
+
+The pistache port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Example
 
 ### Hello World (server)


### PR DESCRIPTION
`pistache` is available as a port in vcpkg, a C++ library manager that simplifies installation for `pistache` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build pistache, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/pistache/portfile.cmake). We try to keep the library maintained as close as possible to the original library.