### PR TITLE
test: listener TLS handshake timeout test

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -22,6 +22,7 @@ jobs:
         os: [ 'debian:stable', 'debian:testing', 'registry.access.redhat.com/ubi8/ubi-minimal', 'registry.access.redhat.com/ubi9/ubi-minimal' ]
         compiler: [ 'gcc', 'clang' ]
         sanitizer: [ 'address', 'undefined', 'none' ] # ThreadSanitizer reports errors
+        tls: [ 'true', 'false' ]
         exclude:
           - os: 'registry.access.redhat.com/ubi8/ubi-minimal'
             sanitizer: 'address'
@@ -56,7 +57,7 @@ jobs:
       if: contains(matrix.os, 'redhat')
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then compiler=gcc-c++; else compiler=llvm-toolset; fi
-        microdnf -y install $compiler pkgconf cmake libcurl-devel git python3-pip unzip
+        microdnf -y install $compiler pkgconf cmake openssl-devel libcurl-devel git python3-pip unzip
         curl -LO https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip
         unzip ninja-linux.zip
         mv ninja /usr/local/bin
@@ -71,7 +72,7 @@ jobs:
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then CXX=g++; else CXX=clang++ CXX_LD=lld; fi
         export CXX CXX_LD
-        meson setup build -DPISTACHE_BUILD_TESTS=true --buildtype=debug -Db_coverage=true -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false
+        meson setup build -DPISTACHE_BUILD_TESTS=true -DPISTACHE_USE_SSL=${{ matrix.tls }} --buildtype=debug -Db_coverage=true -Db_sanitize=${{ matrix.sanitizer }} -Db_lundef=false
       env:
         CC: ${{ matrix.compiler }}
 
@@ -84,7 +85,7 @@ jobs:
     - name: Coverage
       if: ${{ !contains(matrix.os, 'redhat') }}
       run: |
-        mkdir --parents $HOME/.local/bin
+        mkdir -p $HOME/.local/bin
         if [ "${{ matrix.compiler }}" = 'clang' ]; then printf 'llvm-cov gcov "$@"' > $HOME/.local/bin/cov.sh; else printf 'gcov "$@"' > $HOME/.local/bin/cov.sh; fi && chmod +x $HOME/.local/bin/cov.sh
         lcov --capture --output-file coverage.info --directory . --gcov-tool $HOME/.local/bin/cov.sh --exclude '/usr/*' --exclude "${HOME}"'/.cache/*' --exclude '*/tests/*' --exclude '*/subprojects/*'
         lcov --list coverage.info

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -4,7 +4,13 @@
 
 name: linux
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 defaults:
   run:

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -48,9 +48,9 @@ jobs:
     - name: Install dependencies (Debian)
       if: contains(matrix.os, 'debian')
       run: |
-        if [ ${{ matrix.compiler }} = gcc ]; then compiler=g++; else compiler="clang lld"; fi
+        if [ ${{ matrix.compiler }} = gcc ]; then compiler=g++; else compiler="clang lld ?exact-name(libclang-rt-dev)"; fi
         apt -y update
-        apt -y install $compiler meson pkg-config cmake rapidjson-dev libssl-dev '?name(libhowardhinnant-date-dev)' '?name(libgmock-dev) (?version([1-9]\.[1-9][1-9]) | ?version([1-9]\.[2-9][0-9]))' '?name(libcpp-httplib-dev)' libcurl4-openssl-dev git ca-certificates curl gpg gpgv gpg-agent lcov llvm-dev --no-install-recommends
+        apt -y install $compiler meson pkg-config cmake rapidjson-dev libssl-dev '?exact-name(libhowardhinnant-date-dev)' '?exact-name(libgmock-dev) (?version([1-9]\.[1-9][1-9]) | ?version([1-9]\.[2-9][0-9]))' '?exact-name(libcpp-httplib-dev)' libcurl4-openssl-dev git ca-certificates curl gpg gpgv gpg-agent lcov llvm-dev --no-install-recommends
 
     - name: Install dependencies (Red Hat)
       if: contains(matrix.os, 'redhat')

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -56,8 +56,12 @@ jobs:
       if: contains(matrix.os, 'redhat')
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then compiler=gcc-c++; else compiler=llvm-toolset; fi
-        microdnf -y install $compiler pkgconf cmake libcurl-devel git python3-pip
-        pip3 install meson ninja
+        microdnf -y install $compiler pkgconf cmake libcurl-devel git python3-pip unzip
+        curl -LO https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip
+        unzip ninja-linux.zip
+        mv ninja /usr/local/bin
+        rm ninja-linux.zip
+        pip3 install meson
 
     - uses: actions/checkout@v3
       with:

--- a/tests/listener_tls_test.cc
+++ b/tests/listener_tls_test.cc
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Andrea Pappacoda
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <pistache/listener.h>
+
+#include <chrono>
+#include <openssl/bio.h>
+#include <pistache/http.h>
+
+class HelloHandler : public Pistache::Http::Handler
+{
+public:
+    HTTP_PROTOTYPE(HelloHandler)
+
+    void onRequest(const Pistache::Http::Request& /*request*/,
+                   Pistache::Http::ResponseWriter response) override
+    {
+        response.send(Pistache::Http::Code::Ok, "Hello world\n");
+    }
+};
+
+TEST(listener_tls_test, tls_handshake_timeout)
+{
+    using testing::Eq;
+    using testing::Le;
+
+    Pistache::Tcp::Listener listener;
+    listener.init(1);
+    listener.setupSSL("./certs/server.crt", "./certs/server.key", false, nullptr);
+    listener.setHandler(Pistache::Http::make_handler<HelloHandler>());
+    listener.bind(Pistache::Address(Pistache::IP::loopback(), 0));
+    listener.runThreaded();
+
+    // Tell the BIO how to connect to the listener
+    BIO* bio = BIO_new_connect("localhost");
+    BIO_set_conn_port(bio, listener.getPort().toString().c_str());
+
+    const auto pre_handshake = std::chrono::steady_clock::now();
+
+    // Connect to the listener without actually initiating a TLS handshake
+    long success = BIO_do_connect(bio);
+    ASSERT_THAT(success, Eq(1));
+
+    // Try to read something until the listener drops the connection. The
+    // read is expected to fail
+    unsigned char buf[10];
+    success = BIO_read(bio, buf, sizeof buf);
+    EXPECT_THAT(success, Le(0));
+
+    const auto duration = std::chrono::steady_clock::now() - pre_handshake;
+
+    // The timeout shouldn't be longer than 20 seconds by default
+    EXPECT_THAT(duration, Le(std::chrono::seconds(20)));
+
+    BIO_free_all(bio);
+}

--- a/tests/listener_tls_test.cc
+++ b/tests/listener_tls_test.cc
@@ -12,6 +12,9 @@
 #include <openssl/bio.h>
 #include <pistache/http.h>
 
+using testing::Eq;
+using testing::Le;
+
 class HelloHandler : public Pistache::Http::Handler
 {
 public:
@@ -26,9 +29,6 @@ public:
 
 TEST(listener_tls_test, tls_handshake_timeout)
 {
-    using testing::Eq;
-    using testing::Le;
-
     Pistache::Tcp::Listener listener;
     listener.init(1);
     listener.setupSSL("./certs/server.crt", "./certs/server.key", false, nullptr);
@@ -56,6 +56,39 @@ TEST(listener_tls_test, tls_handshake_timeout)
 
     // The timeout shouldn't be longer than 20 seconds by default
     EXPECT_THAT(duration, Le(std::chrono::seconds(20)));
+
+    BIO_free_all(bio);
+}
+
+TEST(listener_tls_test, tls_handshake_timeout_custom)
+{
+    Pistache::Tcp::Listener listener;
+    listener.init(1);
+    listener.setupSSL("./certs/server.crt", "./certs/server.key", false, nullptr, std::chrono::seconds(3));
+    listener.setHandler(Pistache::Http::make_handler<HelloHandler>());
+    listener.bind(Pistache::Address(Pistache::IP::loopback(), 0));
+    listener.runThreaded();
+
+    // Tell the BIO how to connect to the listener
+    BIO* bio = BIO_new_connect("localhost");
+    BIO_set_conn_port(bio, listener.getPort().toString().c_str());
+
+    const auto pre_handshake = std::chrono::steady_clock::now();
+
+    // Connect to the listener without actually initiating a TLS handshake
+    long success = BIO_do_connect(bio);
+    ASSERT_THAT(success, Eq(1));
+
+    // Try to read something until the listener drops the connection. The
+    // read is expected to fail
+    unsigned char buf[10];
+    success = BIO_read(bio, buf, sizeof buf);
+    EXPECT_THAT(success, Le(0));
+
+    const auto duration = std::chrono::steady_clock::now() - pre_handshake;
+
+    // The timeout shouldn't be longer than 5 seconds
+    EXPECT_THAT(duration, Le(std::chrono::seconds(5)));
 
     BIO_free_all(bio);
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -40,7 +40,10 @@ network_tests = ['net_test']
 flaky_tests = []
 
 if get_option('PISTACHE_USE_SSL')
-	pistache_test_files += 'https_server_test'
+	pistache_test_files += [
+		'https_server_test',
+		'listener_tls_test'
+	]
 	subdir('certs')
 endif
 


### PR DESCRIPTION
The new `tls_handshake_timeout` test is source-compatible with Pistache versions with and without the fix in #1115, so that it is easy to test if the bug reproduces with and without that patch applied.