### PR TITLE
ci: automatically update debian/changelog

### DIFF
--- a/.github/workflows/debian-changelog.yaml
+++ b/.github/workflows/debian-changelog.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2023 Andrea Pappacoda
+# SPDX-License-Identifier: Apache-2.0
+
+name: debian-changelog
+
+on:
+  push:
+    branches:
+    - master
+  paths:
+    - version.txt
+
+defaults:
+  run:
+    shell: sh
+
+jobs:
+  debian-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Install dependencies
+      run: |
+        apt update
+        apt -y install --no-install-recommends devscripts git
+
+    - uses: actions/checkout@v3
+
+    - name: Update debian/changelog
+      run: |
+        git switch debian
+        git checkout master -- version.txt
+        export DEBFULLNAME=$(grep '^Maintainer:' control | cut -d : -f 2 | cut -d '<' -f 1 | xargs echo)
+        export DEBEMAIL=$(grep '^Maintainer:' control | cut -d '<' -f 2 | tr -d '>')
+        xargs -I version dch -v version-1 -c changelog '' < version.txt
+      env:
+        TZ: UTC0
+
+    - name: Push updated changelog
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        xargs -I version git commit -m 'changelog: update to version' changelog < version.txt
+        git push


### PR DESCRIPTION
This CI job will run when `version.txt` is updated in the `master` branch, and will push a new commit to the `debian` branch updating the changelog.

`DEBFULLNAME` and `DEBEMAIL` are set by "parsing" the control file. If you know a true debian/control parser that could be used instead, preferably part of dpkg or devscripts, please let me know.

This script currently only updates the single existing changelog entry. It could be possible to make it add a new entry each time instead, but it'd be a bit more involved and we would have to first check if it'd be compatible with our current PPA setup, which I personally don't know very well.

Closes #1119