### PR TITLE
tests/net_test: don't try to resolve external names

### DIFF
--- a/tests/net_test.cc
+++ b/tests/net_test.cc
@@ -106,8 +106,8 @@ TEST(net_test, address_creation)
     ASSERT_EQ(address14.family(), AF_INET);
     ASSERT_EQ(address14.port(), 80);
 
-    Address address15("www.example.com");
-    ASSERT_EQ(address15.host(), "93.184.216.34");
+    Address address15("localhost");
+    ASSERT_EQ(address15.host(), "127.0.0.1");
     ASSERT_EQ(address15.family(), AF_INET);
     ASSERT_EQ(address15.port(), 80);
 


### PR DESCRIPTION
The test case "address_creation" relies on resolving the name www.example.com to succeed. It means that testing the project on environments without access to a DNS server will fail. Use the name "localhost" instead so the local resolver will not need to query a DNS server.