### PR TITLE
docs: update Debian packaging status

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,7 @@ If you have no need to modify the Pistache source, you are strongly recommended 
 
 ### Debian and Ubuntu
 
-We have submitted a [Request for Packaging](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=929593) downstream to Debian. Once we have an official Debian package maintainer intimately familiar with the [Debian Policy Manual](https://www.debian.org/doc/debian-policy/), we can expect to eventually see it become available in Debian and all derivatives (e.g. Ubuntu and many others).
-
-But until then currently Pistache has partially compliant upstream Debianization. Our long term goal is to have our source package properly Debianized downstream by a Debian Policy Manual SME. In the mean time consider using our PPAs to avoid having to build from source.
+Pistache is available in the official repositories since Debian 12 and Ubuntu 23.10, under the package name `libpistache-dev`.
 
 #### Supported Architectures
 


### PR DESCRIPTION
Pistache is now packaged in Debian, and will soon be in Ubuntu too (it is already part of the development snapshot of Ubuntu 23.10)