### PR TITLE
test: more precise GTest assertions

### DIFF
--- a/tests/headers_test.cc
+++ b/tests/headers_test.cc
@@ -20,11 +20,11 @@ TEST(headers_test, accept)
 
     {
         const auto& media = a1.media();
-        ASSERT_TRUE(media.size() == 1U);
+        ASSERT_EQ(media.size(), 1U);
 
         const auto& mime = media[0];
-        ASSERT_TRUE(mime == MIME(Audio, Star));
-        ASSERT_TRUE(mime.q().value_or(Pistache::Http::Mime::Q(0)) == Pistache::Http::Mime::Q(20));
+        ASSERT_EQ(mime, MIME(Audio, Star));
+        ASSERT_EQ(mime.q().value_or(Pistache::Http::Mime::Q(0)), Pistache::Http::Mime::Q(20));
     }
 
     Pistache::Http::Header::Accept a2;
@@ -32,18 +32,18 @@ TEST(headers_test, accept)
 
     {
         const auto& media = a2.media();
-        ASSERT_TRUE(media.size() == 4U);
+        ASSERT_EQ(media.size(), 4U);
 
         const auto& m1 = media[0];
-        ASSERT_TRUE(m1 == MIME(Text, Star));
+        ASSERT_EQ(m1, MIME(Text, Star));
         const auto& m2 = media[1];
-        ASSERT_TRUE(m2 == MIME(Text, Html));
+        ASSERT_EQ(m2, MIME(Text, Html));
         const auto& m3 = media[2];
-        ASSERT_TRUE(m3 == MIME(Text, Html));
+        ASSERT_EQ(m3, MIME(Text, Html));
         auto level = m3.getParam("level");
-        ASSERT_TRUE(level.value_or("") == "1");
+        ASSERT_EQ(level.value_or(""), "1");
         const auto& m4 = media[3];
-        ASSERT_TRUE(m4 == MIME(Star, Star));
+        ASSERT_EQ(m4, MIME(Star, Star));
     }
 
     Pistache::Http::Header::Accept a3;
@@ -52,27 +52,27 @@ TEST(headers_test, accept)
 
     {
         const auto& media = a3.media();
-        ASSERT_TRUE(media.size() == 5U);
+        ASSERT_EQ(media.size(), 5U);
 
-        ASSERT_TRUE(media[0] == MIME(Text, Star));
-        ASSERT_TRUE(media[0].q().value_or(Pistache::Http::Mime::Q(0)) == Pistache::Http::Mime::Q(30));
+        ASSERT_EQ(media[0], MIME(Text, Star));
+        ASSERT_EQ(media[0].q().value_or(Pistache::Http::Mime::Q(0)), Pistache::Http::Mime::Q(30));
 
-        ASSERT_TRUE(media[1] == MIME(Text, Html));
-        ASSERT_TRUE(media[2] == MIME(Text, Html));
-        ASSERT_TRUE(media[3] == MIME(Text, Html));
-        ASSERT_TRUE(media[4] == MIME(Star, Star));
-        ASSERT_TRUE(media[4].q().value_or(Pistache::Http::Mime::Q(0)) == Pistache::Http::Mime::Q::fromFloat(0.5));
+        ASSERT_EQ(media[1], MIME(Text, Html));
+        ASSERT_EQ(media[2], MIME(Text, Html));
+        ASSERT_EQ(media[3], MIME(Text, Html));
+        ASSERT_EQ(media[4], MIME(Star, Star));
+        ASSERT_EQ(media[4].q().value_or(Pistache::Http::Mime::Q(0)), Pistache::Http::Mime::Q::fromFloat(0.5));
     }
 
     Pistache::Http::Header::Accept a4;
     ASSERT_THROW(a4.parse("text/*;q=0.4, text/html;q=0.3,"), std::runtime_error);
     /* Shameless dummy comment to work around syntax highlighting bug in nano...
-   */
+     */
 
     Pistache::Http::Header::Accept a5;
     ASSERT_THROW(a5.parse("text/*;q=0.4, text/html;q=0.3, "), std::runtime_error);
     /* Shameless dummy comment to work around syntax highlighting bug in nano...
-   */
+     */
 }
 
 TEST(headers_test, allow)
@@ -81,29 +81,29 @@ TEST(headers_test, allow)
 
     std::ostringstream os;
     a1.write(os);
-    ASSERT_TRUE(os.str() == "GET");
+    ASSERT_EQ(os.str(), "GET");
     os.str("");
 
     Pistache::Http::Header::Allow a2(
         { Pistache::Http::Method::Post, Pistache::Http::Method::Put });
     a2.write(os);
-    ASSERT_TRUE(os.str() == "POST, PUT");
+    ASSERT_EQ(os.str(), "POST, PUT");
     os.str("");
 
     Pistache::Http::Header::Allow a3;
     a3.addMethod(Pistache::Http::Method::Get);
     a3.write(os);
-    ASSERT_TRUE(os.str() == "GET");
+    ASSERT_EQ(os.str(), "GET");
     os.str("");
     a3.addMethod(Pistache::Http::Method::Options);
     a3.write(os);
-    ASSERT_TRUE(os.str() == "GET, OPTIONS");
+    ASSERT_EQ(os.str(), "GET, OPTIONS");
     os.str("");
 
     Pistache::Http::Header::Allow a4(Pistache::Http::Method::Head);
     a4.addMethods({ Pistache::Http::Method::Get, Pistache::Http::Method::Options });
     a4.write(os);
-    ASSERT_TRUE(os.str() == "HEAD, GET, OPTIONS");
+    ASSERT_EQ(os.str(), "HEAD, GET, OPTIONS");
     os.str("");
 
     Pistache::Http::Header::Allow a5(Pistache::Http::Method::Head);
@@ -111,7 +111,7 @@ TEST(headers_test, allow)
     methods.push_back(Pistache::Http::Method::Get);
     a5.addMethods(methods);
     a5.write(os);
-    ASSERT_TRUE(os.str() == "HEAD, GET");
+    ASSERT_EQ(os.str(), "HEAD, GET");
 }
 
 TEST(headers_test, cache_control)
@@ -122,8 +122,8 @@ TEST(headers_test, cache_control)
         cc.parse(str);
 
         auto directives = cc.directives();
-        ASSERT_TRUE(directives.size() == 1U);
-        ASSERT_TRUE(directives[0].directive() == expected);
+        ASSERT_EQ(directives.size(), 1U);
+        ASSERT_EQ(directives[0].directive(), expected);
     };
 
     auto testTimed = [](std::string str,
@@ -133,10 +133,10 @@ TEST(headers_test, cache_control)
         cc.parse(str);
 
         auto directives = cc.directives();
-        ASSERT_TRUE(directives.size() == 1U);
+        ASSERT_EQ(directives.size(), 1U);
 
-        ASSERT_TRUE(directives[0].directive() == expected);
-        ASSERT_TRUE(directives[0].delta() == std::chrono::seconds(delta));
+        ASSERT_EQ(directives[0].directive(), expected);
+        ASSERT_EQ(directives[0].delta(), std::chrono::seconds(delta));
     };
 
     testTrivial("no-cache", Pistache::Http::CacheDirective::NoCache);
@@ -153,84 +153,84 @@ TEST(headers_test, cache_control)
     Pistache::Http::Header::CacheControl cc1;
     cc1.parse("private, max-age=600");
     auto d1 = cc1.directives();
-    ASSERT_TRUE(d1.size() == 2U);
-    ASSERT_TRUE(d1[0].directive() == Pistache::Http::CacheDirective::Private);
-    ASSERT_TRUE(d1[1].directive() == Pistache::Http::CacheDirective::MaxAge);
-    ASSERT_TRUE(d1[1].delta() == std::chrono::seconds(600));
+    ASSERT_EQ(d1.size(), 2U);
+    ASSERT_EQ(d1[0].directive(), Pistache::Http::CacheDirective::Private);
+    ASSERT_EQ(d1[1].directive(), Pistache::Http::CacheDirective::MaxAge);
+    ASSERT_EQ(d1[1].delta(), std::chrono::seconds(600));
 
     Pistache::Http::Header::CacheControl cc2;
     cc2.parse("public, s-maxage=200, proxy-revalidate");
     auto d2 = cc2.directives();
-    ASSERT_TRUE(d2.size() == 3U);
-    ASSERT_TRUE(d2[0].directive() == Pistache::Http::CacheDirective::Public);
-    ASSERT_TRUE(d2[1].directive() == Pistache::Http::CacheDirective::SMaxAge);
-    ASSERT_TRUE(d2[1].delta() == std::chrono::seconds(200));
-    ASSERT_TRUE(d2[2].directive() == Pistache::Http::CacheDirective::ProxyRevalidate);
+    ASSERT_EQ(d2.size(), 3U);
+    ASSERT_EQ(d2[0].directive(), Pistache::Http::CacheDirective::Public);
+    ASSERT_EQ(d2[1].directive(), Pistache::Http::CacheDirective::SMaxAge);
+    ASSERT_EQ(d2[1].delta(), std::chrono::seconds(200));
+    ASSERT_EQ(d2[2].directive(), Pistache::Http::CacheDirective::ProxyRevalidate);
 
     Pistache::Http::Header::CacheControl cc3(
         Pistache::Http::CacheDirective::NoCache);
     std::ostringstream oss;
     cc3.write(oss);
-    ASSERT_TRUE(oss.str() == "no-cache");
+    ASSERT_EQ(oss.str(), "no-cache");
     oss.str("");
 
     cc3.addDirective(Pistache::Http::CacheDirective::NoStore);
     cc3.write(oss);
-    ASSERT_TRUE(oss.str() == "no-cache, no-store");
+    ASSERT_EQ(oss.str(), "no-cache, no-store");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc4(
         Pistache::Http::CacheDirective::NoTransform);
     cc4.write(oss);
-    ASSERT_TRUE(oss.str() == "no-transform");
+    ASSERT_EQ(oss.str(), "no-transform");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc5(
         Pistache::Http::CacheDirective::OnlyIfCached);
     cc5.write(oss);
-    ASSERT_TRUE(oss.str() == "only-if-cached");
+    ASSERT_EQ(oss.str(), "only-if-cached");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc6(
         Pistache::Http::CacheDirective::Private);
     cc6.write(oss);
-    ASSERT_TRUE(oss.str() == "private");
+    ASSERT_EQ(oss.str(), "private");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc7(
         Pistache::Http::CacheDirective::Public);
     cc7.write(oss);
-    ASSERT_TRUE(oss.str() == "public");
+    ASSERT_EQ(oss.str(), "public");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc8(
         Pistache::Http::CacheDirective::MustRevalidate);
     cc8.write(oss);
-    ASSERT_TRUE(oss.str() == "must-revalidate");
+    ASSERT_EQ(oss.str(), "must-revalidate");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc9(
         Pistache::Http::CacheDirective::ProxyRevalidate);
     cc9.write(oss);
-    ASSERT_TRUE(oss.str() == "proxy-revalidate");
+    ASSERT_EQ(oss.str(), "proxy-revalidate");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc10(Pistache::Http::CacheDirective(
         Pistache::Http::CacheDirective::MaxStale, std::chrono::seconds(12345)));
     cc10.write(oss);
-    ASSERT_TRUE(oss.str() == "max-stale=12345");
+    ASSERT_EQ(oss.str(), "max-stale=12345");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc11(Pistache::Http::CacheDirective(
         Pistache::Http::CacheDirective::MinFresh, std::chrono::seconds(12345)));
     cc11.write(oss);
-    ASSERT_TRUE(oss.str() == "min-fresh=12345");
+    ASSERT_EQ(oss.str(), "min-fresh=12345");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc14(Pistache::Http::CacheDirective(
         Pistache::Http::CacheDirective::SMaxAge, std::chrono::seconds(12345)));
     cc14.write(oss);
-    ASSERT_TRUE(oss.str() == "s-maxage=12345");
+    ASSERT_EQ(oss.str(), "s-maxage=12345");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc15(
@@ -250,7 +250,7 @@ TEST(headers_test, cache_control)
           Pistache::Http::CacheDirective(Pistache::Http::CacheDirective::MaxAge,
                                          std::chrono::seconds(600)) });
     cc12.write(oss);
-    ASSERT_TRUE(oss.str() == "public, max-age=600");
+    ASSERT_EQ(oss.str(), "public, max-age=600");
     oss.str("");
 
     Pistache::Http::Header::CacheControl cc13;
@@ -262,7 +262,7 @@ TEST(headers_test, cache_control)
 
     cc13.addDirectives(cd);
     cc13.write(oss);
-    ASSERT_TRUE(oss.str() == "public, max-age=600");
+    ASSERT_EQ(oss.str(), "public, max-age=600");
 }
 
 TEST(headers_test, content_length)
@@ -272,8 +272,8 @@ TEST(headers_test, content_length)
     cl.parse("3495");
     cl.write(oss);
 
-    ASSERT_TRUE("3495" == oss.str());
-    ASSERT_TRUE(cl.value() == 3495U);
+    ASSERT_EQ("3495", oss.str());
+    ASSERT_EQ(cl.value(), 3495U);
 }
 
 // Verify authorization header with basic method works correctly...
@@ -291,7 +291,7 @@ TEST(headers_test, authorization_basic_test)
 
     // Verify what went in is what came out...
     au.write(oss);
-    ASSERT_TRUE(BasicEncodedValue == oss.str());
+    ASSERT_EQ(BasicEncodedValue, oss.str());
     oss = std::ostringstream();
 
     // Verify authorization header recognizes it is basic method and no other...
@@ -305,12 +305,12 @@ TEST(headers_test, authorization_basic_test)
 
     // Verify it encoded correctly...
     au.write(oss);
-    ASSERT_TRUE(BasicEncodedValue == oss.str());
+    ASSERT_EQ(BasicEncodedValue, oss.str());
     oss = std::ostringstream();
 
     // Verify it decoded correctly...
-    ASSERT_TRUE(au.getBasicUser() == "Aladdin");
-    ASSERT_TRUE(au.getBasicPassword() == "OpenSesame");
+    ASSERT_EQ(au.getBasicUser(), "Aladdin");
+    ASSERT_EQ(au.getBasicPassword(), "OpenSesame");
 }
 
 TEST(headers_test, authorization_bearer_test)
@@ -351,15 +351,15 @@ TEST(headers_test, expect_test)
     e.parse("100-continue");
     e.write(oss);
 
-    ASSERT_TRUE("100-continue" == oss.str());
-    ASSERT_TRUE(e.expectation() == Pistache::Http::Expectation::Continue);
+    ASSERT_EQ("100-continue", oss.str());
+    ASSERT_EQ(e.expectation(), Pistache::Http::Expectation::Continue);
     oss.str("");
 
     e.parse("unknown");
     e.write(oss);
 
     ASSERT_TRUE(oss.str().empty());
-    ASSERT_TRUE(e.expectation() == Pistache::Http::Expectation::Ext);
+    ASSERT_EQ(e.expectation(), Pistache::Http::Expectation::Ext);
     oss.str("");
 }
 
@@ -402,8 +402,8 @@ TEST(headers_test, connection)
         connection.parse(test.data);
         connection.write(oss);
 
-        ASSERT_TRUE(connection.control() == test.expected);
-        ASSERT_TRUE(oss.str() == test.expected_string);
+        ASSERT_EQ(connection.control(), test.expected);
+        ASSERT_EQ(oss.str(), test.expected_string);
     }
 }
 
@@ -417,7 +417,7 @@ TEST(headers_test, date_test_rfc_1123)
     Pistache::Http::Header::Date d1;
     d1.parse("Sun, 06 Nov 1994 08:49:37 GMT");
     auto dd1 = d1.fullDate().date();
-    ASSERT_TRUE(expected_time_point == dd1);
+    ASSERT_EQ(expected_time_point, dd1);
 }
 
 TEST(headers_test, date_test_rfc_850)
@@ -430,7 +430,7 @@ TEST(headers_test, date_test_rfc_850)
     Pistache::Http::Header::Date d2;
     d2.parse("Sunday, 06-Nov-94 08:49:37 GMT");
     auto dd2 = d2.fullDate().date();
-    ASSERT_TRUE(dd2 == expected_time_point);
+    ASSERT_EQ(dd2, expected_time_point);
 }
 
 TEST(headers_test, date_test_asctime)
@@ -443,7 +443,7 @@ TEST(headers_test, date_test_asctime)
     Pistache::Http::Header::Date d3;
     d3.parse("Sun Nov  6 08:49:37 1994");
     auto dd3 = d3.fullDate().date();
-    ASSERT_TRUE(dd3 == expected_time_point);
+    ASSERT_EQ(dd3, expected_time_point);
 }
 
 TEST(headers_test, date_test_ostream)
@@ -454,7 +454,7 @@ TEST(headers_test, date_test_ostream)
     Pistache::Http::Header::Date d4;
     d4.parse("Fri, 25 Jan 2019 21:04:45.000000000 UTC");
     d4.write(os);
-    ASSERT_TRUE("Fri, 25 Jan 2019 21:04:45.000000000 UTC" == os.str());
+    ASSERT_EQ("Fri, 25 Jan 2019 21:04:45.000000000 UTC", os.str());
 }
 
 TEST(headers_test, host)
@@ -464,29 +464,29 @@ TEST(headers_test, host)
     std::ostringstream oss;
     host.write(oss);
 
-    ASSERT_TRUE(host.host() == "www.w3.org");
-    ASSERT_TRUE(host.port() == 80);
-    ASSERT_TRUE(oss.str() == "www.w3.org:80");
+    ASSERT_EQ(host.host(), "www.w3.org");
+    ASSERT_EQ(host.port(), 80);
+    ASSERT_EQ(oss.str(), "www.w3.org:80");
     oss.str("");
 
     host.parse("www.example.com:8080");
     host.write(oss);
 
-    ASSERT_TRUE(host.host() == "www.example.com");
-    ASSERT_TRUE(host.port() == 8080);
-    ASSERT_TRUE(oss.str() == "www.example.com:8080");
+    ASSERT_EQ(host.host(), "www.example.com");
+    ASSERT_EQ(host.port(), 8080);
+    ASSERT_EQ(oss.str(), "www.example.com:8080");
     oss.str("");
 
     host.parse("localhost:8080");
     host.write(oss);
 
-    ASSERT_TRUE(host.host() == "localhost");
-    ASSERT_TRUE(host.port() == 8080);
-    ASSERT_TRUE(oss.str() == "localhost:8080");
+    ASSERT_EQ(host.host(), "localhost");
+    ASSERT_EQ(host.port(), 8080);
+    ASSERT_EQ(oss.str(), "localhost:8080");
     oss.str("");
 
     /* Due to an error in GLIBC these tests don't fail as expected, further
-   * research needed */
+     * research needed */
     //     ASSERT_THROW( host.parse("256.256.256.256:8080");,
     //     std::invalid_argument); ASSERT_THROW( host.parse("1.0.0.256:8080");,
     //     std::invalid_argument);
@@ -494,21 +494,21 @@ TEST(headers_test, host)
     host.parse("[::1]:8080");
     host.write(oss);
 
-    ASSERT_TRUE(host.host() == "[::1]");
-    ASSERT_TRUE(host.port() == 8080);
-    ASSERT_TRUE(oss.str() == "[::1]:8080");
+    ASSERT_EQ(host.host(), "[::1]");
+    ASSERT_EQ(host.port(), 8080);
+    ASSERT_EQ(oss.str(), "[::1]:8080");
     oss.str("");
 
     host.parse("[2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455]:8080");
     host.write(oss);
 
-    ASSERT_TRUE(host.host() == "[2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455]");
-    ASSERT_TRUE(host.port() == 8080);
-    ASSERT_TRUE(oss.str() == "[2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455]:8080");
+    ASSERT_EQ(host.host(), "[2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455]");
+    ASSERT_EQ(host.port(), 8080);
+    ASSERT_EQ(oss.str(), "[2001:0DB8:AABB:CCDD:EEFF:0011:2233:4455]:8080");
     oss.str("");
 
     /* Due to an error in GLIBC these tests don't fail as expected, further
-   * research needed */
+     * research needed */
     //     ASSERT_THROW(
     //     host.parse("[GGGG:GGGG:GGGG:GGGG:GGGG:GGGG:GGGG:GGGG]:8080");,
     //     std::invalid_argument); ASSERT_THROW( host.parse("[::GGGG]:8080");,
@@ -525,7 +525,7 @@ TEST(headers_test, user_agent)
 
     ASSERT_TRUE(
         std::strcmp(os.str().c_str(), "CERN-LineMode/2.15 libwww/2.17b3") == 0);
-    ASSERT_TRUE(ua.agent() == "CERN-LineMode/2.15 libwww/2.17b3");
+    ASSERT_EQ(ua.agent(), "CERN-LineMode/2.15 libwww/2.17b3");
 }
 
 TEST(headers_test, content_encoding)
@@ -534,38 +534,38 @@ TEST(headers_test, content_encoding)
     std::ostringstream oss;
     ce.parse("gzip");
     ce.write(oss);
-    ASSERT_TRUE("gzip" == oss.str());
-    ASSERT_TRUE(ce.encoding() == Pistache::Http::Header::Encoding::Gzip);
+    ASSERT_EQ("gzip", oss.str());
+    ASSERT_EQ(ce.encoding(), Pistache::Http::Header::Encoding::Gzip);
     oss.str("");
 
     ce.parse("deflate");
     ce.write(oss);
-    ASSERT_TRUE("deflate" == oss.str());
-    ASSERT_TRUE(ce.encoding() == Pistache::Http::Header::Encoding::Deflate);
+    ASSERT_EQ("deflate", oss.str());
+    ASSERT_EQ(ce.encoding(), Pistache::Http::Header::Encoding::Deflate);
     oss.str("");
 
     ce.parse("compress");
     ce.write(oss);
-    ASSERT_TRUE("compress" == oss.str());
-    ASSERT_TRUE(ce.encoding() == Pistache::Http::Header::Encoding::Compress);
+    ASSERT_EQ("compress", oss.str());
+    ASSERT_EQ(ce.encoding(), Pistache::Http::Header::Encoding::Compress);
     oss.str("");
 
     ce.parse("identity");
     ce.write(oss);
-    ASSERT_TRUE("identity" == oss.str());
-    ASSERT_TRUE(ce.encoding() == Pistache::Http::Header::Encoding::Identity);
+    ASSERT_EQ("identity", oss.str());
+    ASSERT_EQ(ce.encoding(), Pistache::Http::Header::Encoding::Identity);
     oss.str("");
 
     ce.parse("chunked");
     ce.write(oss);
-    ASSERT_TRUE("chunked" == oss.str());
-    ASSERT_TRUE(ce.encoding() == Pistache::Http::Header::Encoding::Chunked);
+    ASSERT_EQ("chunked", oss.str());
+    ASSERT_EQ(ce.encoding(), Pistache::Http::Header::Encoding::Chunked);
     oss.str("");
 
     ce.parse("unknown");
     ce.write(oss);
-    ASSERT_TRUE("unknown" == oss.str());
-    ASSERT_TRUE(ce.encoding() == Pistache::Http::Header::Encoding::Unknown);
+    ASSERT_EQ("unknown", oss.str());
+    ASSERT_EQ(ce.encoding(), Pistache::Http::Header::Encoding::Unknown);
     oss.str("");
 }
 
@@ -576,10 +576,10 @@ TEST(headers_test, content_type)
     ct.parse("text/html; charset=ISO-8859-4");
     ct.write(oss);
 
-    ASSERT_TRUE("text/html; charset=ISO-8859-4" == oss.str());
+    ASSERT_EQ("text/html; charset=ISO-8859-4", oss.str());
     const auto& mime = ct.mime();
-    ASSERT_TRUE(mime == MIME(Text, Html));
-    ASSERT_TRUE(mime.getParam("charset").value_or("") == "ISO-8859-4");
+    ASSERT_EQ(mime, MIME(Text, Html));
+    ASSERT_EQ(mime.getParam("charset").value_or(""), "ISO-8859-4");
 }
 
 TEST(headers_test, access_control_allow_origin_test)
@@ -590,8 +590,8 @@ TEST(headers_test, access_control_allow_origin_test)
     allowOrigin.parse("http://foo.bar");
     allowOrigin.write(os);
 
-    ASSERT_TRUE(std::strcmp(os.str().c_str(), "http://foo.bar") == 0);
-    ASSERT_TRUE(allowOrigin.uri() == "http://foo.bar");
+    ASSERT_STREQ(os.str().c_str(), "http://foo.bar");
+    ASSERT_EQ(allowOrigin.uri(), "http://foo.bar");
 }
 
 TEST(headers_test, access_control_allow_headers_test)
@@ -603,12 +603,11 @@ TEST(headers_test, access_control_allow_headers_test)
                        "Authorization, X-Requested-With");
     allowHeaders.write(os);
 
-    ASSERT_TRUE(std::strcmp(os.str().c_str(),
-                            "Content-Type, Access-Control-Allow-Headers, "
-                            "Authorization, X-Requested-With")
-                == 0);
-    ASSERT_TRUE(allowHeaders.val() == "Content-Type, Access-Control-Allow-Headers, Authorization, "
-                                      "X-Requested-With");
+    ASSERT_STREQ(os.str().c_str(),
+                 "Content-Type, Access-Control-Allow-Headers, "
+                 "Authorization, X-Requested-With");
+    ASSERT_EQ(allowHeaders.val(), "Content-Type, Access-Control-Allow-Headers, Authorization, "
+                                  "X-Requested-With");
 }
 
 TEST(headers_test, access_control_expose_headers_test)
@@ -619,8 +618,8 @@ TEST(headers_test, access_control_expose_headers_test)
     exposeHeaders.parse("Accept, Location");
     exposeHeaders.write(os);
 
-    ASSERT_TRUE(exposeHeaders.val() == "Accept, Location");
-    ASSERT_TRUE(std::strcmp(os.str().c_str(), "Accept, Location") == 0);
+    ASSERT_EQ(exposeHeaders.val(), "Accept, Location");
+    ASSERT_STREQ(os.str().c_str(), "Accept, Location");
 }
 
 TEST(headers_test, access_control_allow_methods_test)
@@ -631,8 +630,8 @@ TEST(headers_test, access_control_allow_methods_test)
     allowMethods.parse("GET, POST, DELETE");
     allowMethods.write(os);
 
-    ASSERT_TRUE(allowMethods.val() == "GET, POST, DELETE");
-    ASSERT_TRUE(std::strcmp(os.str().c_str(), "GET, POST, DELETE") == 0);
+    ASSERT_EQ(allowMethods.val(), "GET, POST, DELETE");
+    ASSERT_STREQ(os.str().c_str(), "GET, POST, DELETE");
 }
 
 TEST(headers_test, location_test)
@@ -641,13 +640,13 @@ TEST(headers_test, location_test)
     Pistache::Http::Header::Location l0("location");
     std::ostringstream oss;
     l0.write(oss);
-    ASSERT_TRUE("location" == oss.str());
+    ASSERT_EQ("location", oss.str());
     oss.str("");
 
     Pistache::Http::Header::Location l1;
     l1.parse("location");
     l1.write(oss);
-    ASSERT_TRUE("location" == oss.str());
+    ASSERT_EQ("location", oss.str());
     oss.str("");
 }
 
@@ -657,25 +656,25 @@ TEST(headers_test, server_test)
     Pistache::Http::Header::Server s0("server");
     std::ostringstream oss;
     s0.write(oss);
-    ASSERT_TRUE("server" == oss.str());
+    ASSERT_EQ("server", oss.str());
     oss.str("");
 
     std::vector<std::string> tokens({ "server0", "server1" });
     Pistache::Http::Header::Server s1(tokens);
     s1.write(oss);
-    ASSERT_TRUE("server0 server1" == oss.str());
+    ASSERT_EQ("server0 server1", oss.str());
     oss.str("");
 
     std::string token("server");
     Pistache::Http::Header::Server s2(token);
     s2.write(oss);
-    ASSERT_TRUE("server" == oss.str());
+    ASSERT_EQ("server", oss.str());
     oss.str("");
 
     Pistache::Http::Header::Server s3;
     s3.parse("server");
     s3.write(oss);
-    ASSERT_TRUE("server" == oss.str());
+    ASSERT_EQ("server", oss.str());
     oss.str("");
 }
 
@@ -686,13 +685,13 @@ TEST(headers_test, macro_for_custom_headers)
     TestHeader testHeader;
     std::ostringstream os;
 
-    ASSERT_TRUE(strcmp(TestHeader::Name, "TestHeader") == 0);
+    ASSERT_STREQ(TestHeader::Name, "TestHeader");
 
     testHeader.parse("Header Content Test");
     testHeader.write(os);
 
-    ASSERT_TRUE(testHeader.val() == "Header Content Test");
-    ASSERT_TRUE(std::strcmp(os.str().c_str(), "Header Content Test") == 0);
+    ASSERT_EQ(testHeader.val(), "Header Content Test");
+    ASSERT_STREQ(os.str().c_str(), "Header Content Test");
 }
 
 TEST(headers_test, add_new_header_test)
@@ -707,7 +706,7 @@ TEST(headers_test, add_new_header_test)
 
     const auto& headersList = Pistache::Http::Header::Registry::instance().headersList();
     const bool isFound      = std::find(headersList.begin(), headersList.end(),
-                                   headerName)
+                                        headerName)
         != headersList.end();
     ASSERT_TRUE(isFound);
 }
@@ -727,7 +726,7 @@ TEST(headers_test, header_already_registered)
         what = e.what();
     }
 
-    ASSERT_TRUE("Header already registered" == what);
+    ASSERT_EQ("Header already registered", what);
 }
 
 TEST(headers_test, unknown_header)
@@ -745,7 +744,7 @@ TEST(headers_test, unknown_header)
         what = e.what();
     }
 
-    ASSERT_TRUE("Unknown header" == what);
+    ASSERT_EQ("Unknown header", what);
 }
 
 TEST(headers_test, could_not_find_header)
@@ -763,7 +762,7 @@ TEST(headers_test, could_not_find_header)
         what = e.what();
     }
 
-    ASSERT_TRUE("Unknown header" == what);
+    ASSERT_EQ("Unknown header", what);
 }
 
 // Verify registered headers appear in both the client request's strongly typed
@@ -805,8 +804,8 @@ TEST(headers_test, registered_header_in_raw_list)
     // Verify the TestHeader is in the raw list as expected...
     const auto foundRawHeader = rawHeadersList.find(TestHeader::Name);
     ASSERT_TRUE(foundRawHeader != rawHeadersList.end());
-    ASSERT_TRUE(foundRawHeader->second.name() == TestHeader::Name);
-    ASSERT_TRUE(foundRawHeader->second.value() == "some data");
+    ASSERT_EQ(foundRawHeader->second.name(), TestHeader::Name);
+    ASSERT_EQ(foundRawHeader->second.value(), "some data");
 }
 
 TEST(headers_test, raw_headers_are_case_insensitive)
@@ -857,6 +856,6 @@ TEST(headers_test, cookie_headers_are_case_insensitive)
 
         // the cookies should still exist.
         ASSERT_TRUE(request.cookies().has("x"));
-        ASSERT_TRUE(request.cookies().get("x").value == "y");
+        ASSERT_EQ(request.cookies().get("x").value, "y");
     }
 }

--- a/tests/http_client_test.cc
+++ b/tests/http_client_test.cc
@@ -166,7 +166,7 @@ TEST(http_client_test, one_client_with_multiple_requests)
     server.shutdown();
     client.shutdown();
 
-    ASSERT_TRUE(response_counter == RESPONSE_SIZE);
+    ASSERT_EQ(response_counter, RESPONSE_SIZE);
 }
 
 TEST(http_client_test, multiple_clients_with_one_request)
@@ -232,7 +232,7 @@ TEST(http_client_test, multiple_clients_with_one_request)
     client2.shutdown();
     client3.shutdown();
 
-    ASSERT_TRUE(response_counter == CLIENT_SIZE);
+    ASSERT_EQ(response_counter, CLIENT_SIZE);
 }
 
 TEST(http_client_test, timeout_reject)
@@ -314,7 +314,7 @@ TEST(
     server.shutdown();
     client.shutdown();
 
-    ASSERT_TRUE(response_counter == RESPONSE_SIZE);
+    ASSERT_EQ(response_counter, RESPONSE_SIZE);
 }
 
 TEST(
@@ -363,7 +363,7 @@ TEST(
     server.shutdown();
     client.shutdown();
 
-    ASSERT_TRUE(response_counter == RESPONSE_SIZE);
+    ASSERT_EQ(response_counter, RESPONSE_SIZE);
 }
 
 TEST(http_client_test, test_client_timeout)

--- a/tests/view_test.cc
+++ b/tests/view_test.cc
@@ -82,7 +82,7 @@ TEST(view_test, string_test)
     ASSERT_EQ(v1, "Hello");
 
     auto v2 = make_view(s1, 3);
-    ASSERT_TRUE(std::strcmp(v2.data(), "Hel"));
+    ASSERT_STRNE(v2.data(), "Hel");
     ASSERT_EQ(v2, "Hel");
 
     std::string s3(s1);


### PR DESCRIPTION
Using `EXPECT_EQ(var1, var2)` instead of `EXPECT_TRUE(var1 == var2)` offers more helpful error messages in case of test failures. The same goes for `EXPECT_STREQ("str1", "str2")` vs `EXPECT_EQ(strcmp("str1", "str2"), 0)`.