### PR TITLE
build: set soname to major.minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0
 [![codecov](https://codecov.io/gh/pistacheio/pistache/branch/master/graph/badge.svg)](https://codecov.io/gh/pistacheio/pistache)
 [![REUSE status](https://api.reuse.software/badge/github.com/pistacheio/pistache)](https://api.reuse.software/info/github.com/pistacheio/pistache)
 
-Pistache is a modern and elegant HTTP and REST framework for C++. It is entirely written in pure-C++17[*](#linux-only) and provides a clear and pleasant API.
+Pistache is a modern and elegant HTTP and REST framework for C++. It is entirely written in pure-C++17[\*](#linux-only) and provides a clear and pleasant API.
 
 ## Documentation
 
@@ -42,7 +42,7 @@ The [Launchpad Team](https://launchpad.net/~pistache+team) administers the daily
 
 ### Versioning
 
-The version of the library's public interface (ABI) is not the same as the release version, but we choose to always guarantee that the major release version and the soname version will match. The interface version is primarily associated with the _external_ interface of the library. Different platforms handle this differently, such as AIX, GNU/Linux, and Solaris.
+The version of the library's public interface (ABI) is not the same as the release version, but we plan to always guarantee that the major release version and the soname version will match after the 1.0 release; until that, the soname version will follow feature releases. The interface version is primarily associated with the _external_ interface of the library. Different platforms handle this differently, such as AIX, GNU/Linux, and Solaris.
 
 GNU Libtool abstracts each platform's idiosyncrasies away because it is more portable than using `ar(1)` or `ranlib(1)` directly. However, it is [not supported in Meson](https://mesonbuild.com/FAQ.html#how-do-i-do-the-equivalent-of-libtools-exportsymbol-and-exportregex) so we made do without it by setting the SONAME directly.
 
@@ -50,7 +50,7 @@ When Pistache is installed it will normally ship:
 
 - `libpistache.so.X.Y.Z`: This is the actual shared-library binary file. The _X_, _Y_ and _Z_ values are the major, minor and patch interface versions respectively.
 
-- `libpistache.so.X`: This is the _soname_ soft link that points to the binary file. It is what other programs and other libraries reference internally. You should never need to directly reference this file in your build environment.
+- `libpistache.so.X.Y`: This is the _soname_ soft link that points to the binary file. It is what other programs and other libraries reference internally. You should never need to directly reference this file in your build environment.
 
 - `libpistache.so`: This is the _linker name_ entry. This is also a soft link that refers to the soname with the highest major interface version. This linker name is what is referred to on the linker command line.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,7 +75,7 @@ if (BUILD_SHARED_LIBS)
     set_target_properties(pistache_shared PROPERTIES
         OUTPUT_NAME ${PROJECT_NAME}
         VERSION ${pistache_VERSION}
-        SOVERSION ${pistache_VERSION_MAJOR}
+        SOVERSION "${pistache_VERSION_MAJOR}.${pistache_VERSION_MINOR}"
     )
 endif ()
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,6 +41,7 @@ libpistache = library(
 	include_directories: incl_pistache,
 	dependencies: deps_libpistache,
 	install: get_option('PISTACHE_INSTALL'),
+	soversion: version_major + '.' + version_minor,
 	version: version_str,
 	pic: get_option('b_staticpic')
 )


### PR DESCRIPTION
Until the 1.0 release, setting the soname to `version_major.version_minor` gives us more freedom to make changes without being too restricted by ABI compatibility.

We never actually really commited to ABI stability before the 1.0 relase - the README states that at the bottom - but I made this decision clearer by updating the "versioning" section.