### PR TITLE
build: better handle public compile arguments

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -31,26 +31,24 @@ pistache_client_src = [
 	'client'/'client.cc'
 ]
 
-compile_args = []
+public_args = []
 
 if get_option('PISTACHE_USE_SSL')
-	add_project_arguments('-DPISTACHE_USE_SSL', language: 'cpp')
-	compile_args += '-DPISTACHE_USE_SSL'
+	public_args += '-DPISTACHE_USE_SSL'
 endif
 
 if get_option('PISTACHE_USE_CONTENT_ENCODING_BROTLI')
-	add_project_arguments('-DPISTACHE_USE_CONTENT_ENCODING_BROTLI', language: 'cpp')
-	compile_args += '-DPISTACHE_USE_CONTENT_ENCODING_BROTLI'
+	public_args += '-DPISTACHE_USE_CONTENT_ENCODING_BROTLI'
 endif
 
 if get_option('PISTACHE_USE_CONTENT_ENCODING_DEFLATE')
-	add_project_arguments('-DPISTACHE_USE_CONTENT_ENCODING_DEFLATE', language: 'cpp')
-	compile_args += '-DPISTACHE_USE_CONTENT_ENCODING_DEFLATE'
+	public_args += '-DPISTACHE_USE_CONTENT_ENCODING_DEFLATE'
 endif
 
 libpistache = library(
 	'pistache',
 	sources: pistache_common_src + pistache_server_src + pistache_client_src,
+	cpp_args: public_args,
 	include_directories: incl_pistache,
 	dependencies: deps_libpistache,
 	install: get_option('PISTACHE_INSTALL'),
@@ -58,7 +56,11 @@ libpistache = library(
 	pic: get_option('b_staticpic')
 )
 
-pistache_dep = declare_dependency(link_with: libpistache, include_directories: incl_pistache)
+pistache_dep = declare_dependency(
+	compile_args: public_args,
+	include_directories: incl_pistache,
+	link_with: libpistache
+)
 
 if meson.version().version_compare('>=0.54.0')
 	meson.override_dependency('libpistache', pistache_dep)
@@ -71,5 +73,5 @@ import('pkgconfig').generate(
 	url: 'https://pistacheio.github.io/pistache/',
 	version: '@0@-git@1@'.format(version_str, version_git_date),
 	filebase: 'libpistache',
-	extra_cflags: compile_args
+	extra_cflags: public_args
 )


### PR DESCRIPTION
Public arguments are now specifically added to the libpistache and pistache_dep objects, so that they automatically get propagated to all the build targets which depend on pistache_dep.

Follow-up to 575ccf415232dfbafb827b0fcde68f6657e8f7dd