### PR TITLE
control: make -dev package depend on libbrotli-dev

### DIFF
--- a/control
+++ b/control
@@ -38,6 +38,7 @@ Package: libpistache-dev
 Section: libdevel
 Architecture: any
 Depends: libpistache0 (= ${binary:Version}),
+         libbrotli-dev,
          libssl-dev,
          rapidjson-dev,
          zlib1g-dev | libz-dev


### PR DESCRIPTION
This is needed for pkg-config to work properly, since it requires that .pc files are installed even for Requires.private dependencies.

Should fix the issues described in <https://github.com/pistacheio/pistache/issues/1185#issuecomment-1887916403>