### PR TITLE
test: fix integer overflow in cookie_test

### DIFF
--- a/tests/cookie_test.cc
+++ b/tests/cookie_test.cc
@@ -116,7 +116,7 @@ TEST(cookie_test, write_test)
     Cookie c2("lang", "en-US");
     using namespace std::chrono;
 
-    FullDate::time_point expires = date::sys_days(date::year { 118 } / 2 / 16) + hours(17);
+    FullDate::time_point expires = date::sys_days(date::year { 2018 } / 2 / 16) + hours(17);
 
     c2.path    = std::string("/");
     c2.expires = FullDate(expires);


### PR DESCRIPTION
Citing @dgreatwood:

the line that goes wrong in cookie_test.cc is this:

    FullDate::time_point expires = date::sys_days(date::year { 118 } / 2 / 16) + hours(17);

The first puzzle (to me!) is what  "year { 118 }" means. Per:

https://en.cppreference.com/w/cpp/chrono/year/year

> This is constructing an instance of std::chrono::year with value 118. Per:

https://en.cppreference.com/w/cpp/chrono/year_month_day/operator_days

The "118" is a value in the "proleptic Gregorian calendar", i.e. it means the year 118 A.D.

Then sys_days is an operator that converts std::chrono::year_month_day to a std::chrono::time_point

https://en.cppreference.com/w/cpp/chrono/year_month_day/operator_days

Also note that:

> 1) If ok() is true, the return value holds a count of days from the std::chrono::system_clock epoch (1970-01-01) to *this. The result is negative if *this represent a date prior to it.

Indeed, in this case the value is a long way prior to 1970, ~675K days before in fact.

If I had to guess, the standard library is calculating the difference in milliseconds (roughly -1 trillion ms) or in microseconds and causing the overflow.

How about we change that "118" to "2018" (perhaps the cookie_test.cc has some reason for it to be in the past) and try again?