### PR TITLE
Only install githooks for local checkouts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,8 @@ project(
 	meson_version: '>=0.53.2'
 )
 
+fs = import('fs')
+
 #macOS host_machine.system() is 'darwin'
 
 if host_machine.system() != 'linux' and host_machine.system() != 'darwin'
@@ -137,7 +139,7 @@ endif
 
 version_array = []
 if meson.version().version_compare('>=0.57.0')
-	version_array = import('fs').read('version.txt').strip().split('.')
+	version_array = fs.read('version.txt').strip().split('.')
 else
 	# Ugly workaround for reading a file
 	version_array = run_command(
@@ -178,7 +180,7 @@ endif
 
 if not meson.is_subproject()
 	git = find_program('git', required: false)
-	if git.found()
+	if git.found() and fs.is_dir(meson.source_root()/'.git')
 		run_command(git, 'config', '--local', 'core.hooksPath', meson.source_root()/'.hooks', check: false)
 	endif
 endif

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@ project(
 		'b_lto=false',
 		'warning_level=3'
 	],
-	meson_version: '>=0.50.0'
+	meson_version: '>=0.53.2'
 )
 
 #macOS host_machine.system() is 'darwin'


### PR DESCRIPTION
Some tools, such as Buildroot, will use packed tarballs of cloned git repositories and trigger builds for the sources.

Currently, pistache will install githooks via `git config --local` for any build, even if it's not done from a git checkout. Since the source/build directory is not an actual git checkout, the command traverses up the directory hierarchy and will corrupt the git config for the Buildroot checkout.

```
Buildroot/
  .git/config  # <- this gets corrupted
  output/
    build/
      unpacked-pistache-@-commit-hash-without-.git-directory/
```

Now, we check that the source root directory has a `.git` directory before attempting to install githooks.

Fixes #1126 