### PR TITLE
control: require meson 0.53.2+

### DIFF
--- a/control
+++ b/control
@@ -7,7 +7,7 @@ Section: libs
 Priority: optional
 Maintainer: Kip Warner <kip@thevertigo.com>
 Standards-Version: 4.6.0
-Build-Depends: debhelper-compat (= 13), meson (>= 0.50.0)
+Build-Depends: debhelper-compat (= 13), meson (>= 0.53.2)
 Build-Depends-Arch: libbrotli-dev,
                     libcurl4-openssl-dev,
                     libevent-dev,


### PR DESCRIPTION
In lockstep with #1218 for #1126 