### PR TITLE
fix: avoid using %Z format specifier with gmtime()

### DIFF
--- a/src/common/http_defs.cc
+++ b/src/common/http_defs.cc
@@ -129,9 +129,13 @@ namespace Pistache::Http
             date::to_stream(os, "%a, %d %b %Y %T %Z", date_);
             break;
         case Type::RFC1123GMT: {
-            // Requires GMT so we must use std::gmtime to convert to GMT
+            // Requires GMT so we must use std::gmtime to convert to GMT.
+            // We cannot use "%Z" since that refers to the local time zone name,
+            // not the name associated with the std::tm object (since std::tm
+            // isn't guaranteed to have a tm_zone field - it only does on
+            // POSIX.1-2024 systems).
             time_t t = std::chrono::system_clock::to_time_t(date_);
-            os << std::put_time(std::gmtime(&t), "%a, %d %b %Y %T %Z");
+            os << std::put_time(std::gmtime(&t), "%a, %d %b %Y %T GMT");
         }
         break;
         case Type::RFC850:


### PR DESCRIPTION
The `put_time()` function formats dates according to `strftime()`. Its `Z` conversion specifier, according to cppreference, doesn't print the time zone name of the `std::tm` pointer passed to `strftime()`, but instead the time zone name associated with the current locale; citing the [`strftime()`
documentation](https://en.cppreference.com/w/cpp/chrono/c/strftime):

> |  Conversion specifier | Explanation | Used fields |
> | --- | --- | --- |
> | Z | writes locale-dependent time zone name or abbreviation, or no characters if the time zone information is not available | tm_isdst |

In fact, according to the C++ standard, `strftime()` can never print the time zone information associated with a an `std::tm` object, because it doesn't even have a struct member representing it!

But still, you've probably noticed that `strtime()` on your system behaves differently whether you pass in an `std::tm` obtained via `std::localtime` and `std::gmtime`, right? Well, that's because of GNU (and as of 2024, POSIX). If fact, POSIX extends the C standard and mandates that an `std::tm` object also has to contain a `tm_zone` member, which contains time zone information. POSIX also extends `strftime()` function to make use of this new `tm_zone` member when printing `%Z`; this also applies to glibc and musl.

In short: our code is wrong according to the C and C++ standards, and only works correctly on systems either implementing POSIX-2024 or the GNU-like extensions.

If we want to only rely on the C++ standard, we have to either:

- use `%Z` only when we want to print a local time
- use `GMT` or `UTC` when we want to print a time expressed in UTC

This patch does exactly that: instead of using `%Z` to print a gmtime(), "GMT" is used explicitly.

Discovered by Duncan while porting to NetBSD. Thanks!