### PR TITLE
build: make rapidjson_dep a public dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,8 @@ deps_libpistache = [
 ]
 
 if get_option('PISTACHE_USE_RAPIDJSON')
-	deps_libpistache += dependency('RapidJSON', fallback: ['rapidjson', 'rapidjson_dep'])
+	rapidjson_dep = dependency('RapidJSON', fallback: ['rapidjson', 'rapidjson_dep'])
+	deps_libpistache += rapidjson_dep
 endif
 
 # Support Brotli compressed Content-Encoding responses...

--- a/src/meson.build
+++ b/src/meson.build
@@ -76,7 +76,8 @@ libpistache = library(
 pistache_dep = declare_dependency(
 	compile_args: public_args,
 	include_directories: incl_pistache,
-	link_with: libpistache
+	link_with: libpistache,
+	dependencies: [ rapidjson_dep ]
 )
 
 if meson.version().version_compare('>=0.54.0')


### PR DESCRIPTION
Since a RapidJSON header is included in
include/pistache/serializer/rapidjson.h, users using pistache must also add RapidJSON to their include path. Adding rapidjson_dep to the list of dependencies of pistache_dep makes rapidjson_dep a transitive (public) dependency, doing just that.

Should fix the issue encountered by Duncan in
<https://github.com/pistacheio/pistache/pull/1221/files#r1693921738>. Also closes https://github.com/pistacheio/pistache/pull/1224