### PR TITLE
Add zstd compression support to package build dependencies

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,4 @@
-pistache (0.4.7.20240930-1) UNRELEASED; urgency=low
+pistache (0.4.8.20241011-1) UNRELEASED; urgency=low
 
   * Bumped version.
 

--- a/control
+++ b/control
@@ -11,6 +11,7 @@ Build-Depends: debhelper-compat (= 13), meson (>= 0.53.2)
 Build-Depends-Arch: libbrotli-dev,
                     libcurl4-openssl-dev,
                     libevent-dev,
+                    libzstd-dev,
                     libgmock-dev (>= 1.11.0) <!nocheck> | googletest (>= 1.11.0) <!nocheck>,
                     libssl-dev,
                     netbase <!nocheck>,
@@ -40,6 +41,7 @@ Section: libdevel
 Architecture: any
 Depends: libpistache0 (= ${binary:Version}),
          libbrotli-dev,
+         libzstd-dev,
          libssl-dev,
          rapidjson-dev,
          zlib1g-dev | libz-dev

--- a/rules
+++ b/rules
@@ -37,9 +37,8 @@ override_dh_auto_configure:
 		-DPISTACHE_BUILD_DOCS=false \
 		-DPISTACHE_USE_SSL=true \
 		-DPISTACHE_USE_CONTENT_ENCODING_BROTLI=true \
-		-DPISTACHE_USE_CONTENT_ENCODING_DEFLATE=true
+		-DPISTACHE_USE_CONTENT_ENCODING_DEFLATE=true \
 		-DPISTACHE_USE_CONTENT_ENCODING_ZSTD=true
-
 override_dh_auto_test:
 	dh_auto_test -- \
 		--no-suite=network

--- a/rules
+++ b/rules
@@ -38,6 +38,7 @@ override_dh_auto_configure:
 		-DPISTACHE_USE_SSL=true \
 		-DPISTACHE_USE_CONTENT_ENCODING_BROTLI=true \
 		-DPISTACHE_USE_CONTENT_ENCODING_DEFLATE=true
+		-DPISTACHE_USE_CONTENT_ENCODING_ZSTD=true
 
 override_dh_auto_test:
 	dh_auto_test -- \


### PR DESCRIPTION
Following #1247 and #1200

Adds libzstd-dev to build dependencies