### PR TITLE
Fix libzstd-dev on debian build

### DIFF
--- a/control
+++ b/control
@@ -11,7 +11,7 @@ Build-Depends: debhelper-compat (= 13), meson (>= 0.53.2)
 Build-Depends-Arch: libbrotli-dev,
                     libcurl4-openssl-dev,
                     libevent-dev,
-                    libzstd-dev,
+                    libzstd-dev (>= 1.5.4),
                     libgmock-dev (>= 1.11.0) <!nocheck> | googletest (>= 1.11.0) <!nocheck>,
                     libssl-dev,
                     netbase <!nocheck>,
@@ -41,7 +41,7 @@ Section: libdevel
 Architecture: any
 Depends: libpistache0 (= ${binary:Version}),
          libbrotli-dev,
-         libzstd-dev,
+         libzstd-dev (>= 1.5.4),
          libssl-dev,
          rapidjson-dev,
          zlib1g-dev | libz-dev


### PR DESCRIPTION
From #1247 

This patch fixes issues mentioned by @kiplingw on https://github.com/pistacheio/pistache/pull/1247#issuecomment-2469344358.

The issue was caused because the patch that adds zstd support uses the _ZSTD_defaultCLevel()_ function. which is [only supported by libzstd v1.5.0+](https://raw.githack.com/facebook/zstd/release/doc/zstd_manual.html#Chapter3). The current configuration uses libzstd v1.4.8

This PR fixes that by specifying that pistache depends on libzstd >= 1.5.4.