### PR TITLE
Fix errno include error

### DIFF
--- a/include/pistache/common.h
+++ b/include/pistache/common.h
@@ -20,10 +20,10 @@
 
 #include <pistache/winornix.h>
 
-#include PIST_QUOTE(PST_STRERROR_R_HDR)
+#include PST_STRERROR_R_HDR
 
-#include PIST_QUOTE(PST_NETDB_HDR)
-#include PIST_QUOTE(PST_SOCKET_HDR)
+#include PST_NETDB_HDR
+#include PST_SOCKET_HDR
 
 #include <sys/types.h>
 

--- a/include/pistache/eventmeth.h
+++ b/include/pistache/eventmeth.h
@@ -209,7 +209,7 @@ namespace Pistache
 #include <map>
 #include <condition_variable>
 
-#include PIST_QUOTE(PST_FCNTL_HDR) // For FD_CLOEXEC and O_NONBLOCK
+#include PST_FCNTL_HDR // For FD_CLOEXEC and O_NONBLOCK
 
 /* ------------------------------------------------------------------------- */
 

--- a/include/pistache/listener.h
+++ b/include/pistache/listener.h
@@ -24,7 +24,7 @@
 #include <pistache/ssl_wrappers.h>
 #include <pistache/tcp.h>
 
-#include PIST_QUOTE(PST_SYS_RESOURCE_HDR)
+#include PST_SYS_RESOURCE_HDR
 
 #include <memory>
 #include <thread>

--- a/include/pistache/mailbox.h
+++ b/include/pistache/mailbox.h
@@ -14,12 +14,12 @@
 
 #include <pistache/winornix.h>
 
-#include PIST_QUOTE(PST_STRERROR_R_HDR)
+#include PST_STRERROR_R_HDR
 
 #include <pistache/eventmeth.h>
 #include <pistache/pist_quote.h>
 
-#include PIST_QUOTE(PIST_SOCKFNS_HDR)
+#include PIST_SOCKFNS_HDR
 
 #include <pistache/common.h>
 #include <pistache/os.h>

--- a/include/pistache/net.h
+++ b/include/pistache/net.h
@@ -19,16 +19,16 @@
 
 #include <pistache/winornix.h>
 
-#include PIST_QUOTE(PST_NETDB_HDR)
+#include PST_NETDB_HDR
 
 // netinet/in.h defines in_port_t, in_addr_t, in_addr, sockaddr_in,
 // sockaddr_in6, IPPROTO_IP, INADDR_ANY, etc.
-#include PIST_QUOTE(PST_NETINET_IN_HDR)
+#include PST_NETINET_IN_HDR
 
-#include PIST_QUOTE(PST_SOCKET_HDR)
-#include PIST_QUOTE(PST_SYS_UN_HDR)
+#include PST_SOCKET_HDR
+#include PST_SYS_UN_HDR
 
-#include PIST_QUOTE(PIST_SOCKFNS_HDR)
+#include PIST_SOCKFNS_HDR
 
 #ifndef _KERNEL_FASTOPEN
 #define _KERNEL_FASTOPEN

--- a/include/pistache/pist_check.h
+++ b/include/pistache/pist_check.h
@@ -15,7 +15,7 @@
 #define INCLUDED_PSCHECK_H
 
 #include <mutex>
-
+#include <pistache/pist_quote.h>
 #include "pist_syslog.h"
 
 // If DEBUG is enabled, PS_LOGDBG_STACK_TRACE logs a stack trace

--- a/include/pistache/pist_timelog.h
+++ b/include/pistache/pist_timelog.h
@@ -19,7 +19,7 @@
 #include <pistache/winornix.h>
 #include <pistache/emosandlibevdefs.h> // For _IS_BSD
 
-#include PIST_QUOTE(PST_CLOCK_GETTIME_HDR) // for clock_gettime and asctime
+#include PST_CLOCK_GETTIME_HDR // for clock_gettime and asctime
 #include <stdio.h> // snprintf
 #include <stdarg.h> // for vsnprintf
 

--- a/include/pistache/ps_basename.h
+++ b/include/pistache/ps_basename.h
@@ -13,7 +13,7 @@
 
 #include <pistache/winornix.h>
 
-#include PIST_QUOTE(PST_MAXPATH_HDR) // for PST_MAXPATHLEN
+#include PST_MAXPATH_HDR // for PST_MAXPATHLEN
 /* ------------------------------------------------------------------------- */
 
 #ifdef __APPLE__

--- a/include/pistache/pst_errno.h
+++ b/include/pistache/pst_errno.h
@@ -8,7 +8,7 @@
 //
 // Note that we use this intermediate include, rather than just relying solely
 // on defining PST_ERRNO_HDR to be 'errno.h' for Windows, because of mingw
-// gcc's treatment of errno as a macro - 'include PIST_QUOTE(PST_ERRNO_HDR)',
+// gcc's treatment of errno as a macro - 'include PST_ERRNO_HDR',
 // with PST_ERRNO_HDR defined as 'errno.h', can translate to "(*_errno()).h",
 // which is not what we want.
 //

--- a/include/pistache/timer_pool.h
+++ b/include/pistache/timer_pool.h
@@ -25,7 +25,7 @@
 #include <vector>
 
 #include <cassert>
-#include PIST_QUOTE(PST_MISC_IO_HDR) // e.g. unistd.h
+#include PST_MISC_IO_HDR // e.g. unistd.h
 
 namespace Pistache
 {

--- a/include/pistache/transport.h
+++ b/include/pistache/transport.h
@@ -16,8 +16,6 @@
 
 #include PST_SYS_RESOURCE_HDR // for PST_RUSAGE + PST_GETRUSAGE
 
-#include <pistache/pist_timelog.h>
-#include <pistache/pist_quote.h>
 #include <pistache/async.h>
 #include <pistache/mailbox.h>
 #include <pistache/pist_quote.h>

--- a/include/pistache/transport.h
+++ b/include/pistache/transport.h
@@ -14,7 +14,7 @@
 
 #include <pistache/winornix.h>
 
-#include PIST_QUOTE(PST_SYS_RESOURCE_HDR) // for PST_RUSAGE + PST_GETRUSAGE
+#include PST_SYS_RESOURCE_HDR // for PST_RUSAGE + PST_GETRUSAGE
 
 #include <pistache/pist_timelog.h>
 #include <pistache/pist_quote.h>

--- a/include/pistache/winornix.h
+++ b/include/pistache/winornix.h
@@ -12,8 +12,6 @@
 #ifndef _WINORNIX_H_
 #define _WINORNIX_H_
 
-#include <pistache/pist_quote.h>
-
 // DO NOT include emosandlibevdefs.h here
 // emosandlibevdefs.h includes winornix.h, and depends on it
 
@@ -66,11 +64,11 @@
 #define PST_GETRUSAGE getrusage
 #endif
 
-// Use #include PIST_QUOTE(PST_SYS_RESOURCE_HDR)
+// Use #include PST_SYS_RESOURCE_HDR
 #ifdef _IS_WINDOWS
-#define PST_SYS_RESOURCE_HDR pistache/pist_resource.h
+#define PST_SYS_RESOURCE_HDR "pistache/pist_resource.h"
 #else
-#define PST_SYS_RESOURCE_HDR sys/resource.h
+#define PST_SYS_RESOURCE_HDR "sys/resource.h"
 #endif
 
 #ifdef _IS_WINDOWS
@@ -150,45 +148,45 @@ typedef int PST_SOCK_OPT_VAL_T;
 // #define PST_CLOCK_BOOTTIME_ALARM CLOCK_BOOTTIME_ALARM
 #endif
 
-// Use #include PIST_QUOTE(PST_CLOCK_GETTIME_HDR)
+// Use #include PST_CLOCK_GETTIME_HDR
 #ifdef _IS_WINDOWS
-#define PST_CLOCK_GETTIME_HDR pistache/pist_clock_gettime.h
+#define PST_CLOCK_GETTIME_HDR "pistache/pist_clock_gettime.h"
 #else
-#define PST_CLOCK_GETTIME_HDR time.h
+#define PST_CLOCK_GETTIME_HDR "time.h"
 #endif
 
-// Use #include PIST_QUOTE(PST_IFADDRS_HDR)
+// Use #include PST_IFADDRS_HDR
 #ifdef _IS_WINDOWS
-#define PST_IFADDRS_HDR pistache/pist_ifaddrs.h
+#define PST_IFADDRS_HDR "pistache/pist_ifaddrs.h"
 #else
-#define PST_IFADDRS_HDR ifaddrs.h
+#define PST_IFADDRS_HDR "ifaddrs.h"
 #endif
 
-// Use #include PIST_QUOTE(PST_MAXPATH_HDR)
+// Use #include PST_MAXPATH_HDR
 #ifdef _IS_WINDOWS
-#define PST_MAXPATH_HDR Stdlib.h
+#define PST_MAXPATH_HDR "Stdlib.h"
 #define PST_MAXPATHLEN _MAX_PATH
 #elif defined __APPLE__
-#define PST_MAXPATH_HDR sys/syslimits.h
+#define PST_MAXPATH_HDR "sys/syslimits.h"
 #define PST_MAXPATHLEN PATH_MAX
 #else
-#define PST_MAXPATH_HDR sys/param.h
+#define PST_MAXPATH_HDR "sys/param.h"
 #define PST_MAXPATHLEN MAXPATHLEN
 #endif
 
 // Do this so the PST_DECL_SE_ERR_P_EXTRA / PST_STRERROR_R_ERRNO macros have
 // PST_MAXPATHLEN fully defined
-#include PIST_QUOTE(PST_MAXPATH_HDR)
+#include PST_MAXPATH_HDR
 
-// Use #include PIST_QUOTE(PST_STRERROR_R_HDR)
+// Use #include PST_STRERROR_R_HDR
 // mingw gcc doesn't define strerror_r (Oct/2024)
 // gcc on macOS does define strerror_r, but the XSI version not the POSIX one
 #if defined(__linux__) || (defined(__GNUC__) && (!defined(__MINGW32__)) && \
       (!defined(__clang__)) && (!defined(__NetBSD__)) && (!defined(__APPLE__)))
-#define PST_STRERROR_R_HDR string.h
+#define PST_STRERROR_R_HDR "string.h"
 #define PST_STRERROR_R strerror_r // returns char *
 #else
-#define PST_STRERROR_R_HDR pistache/pist_strerror_r.h
+#define PST_STRERROR_R_HDR "pistache/pist_strerror_r.h"
 #define PST_STRERROR_R pist_strerror_r // returns char *
 #endif
 
@@ -204,9 +202,9 @@ typedef int PST_SOCK_OPT_VAL_T;
 #define PST_DBG_DECL_SE_ERR_P_EXTRA
 #endif
 
-// Use #include PIST_QUOTE(PST_FCNTL_HDR)
+// Use #include PST_FCNTL_HDR
 #ifdef _IS_WINDOWS
-#define PST_FCNTL_HDR pistache/pist_fcntl.h
+#define PST_FCNTL_HDR "pistache/pist_fcntl.h"
 #define PST_FCNTL pist_fcntl
 
 // As per Linux /usr/include/x86_64-linux-gnu/bits/fcntl-linux.h
@@ -216,7 +214,7 @@ typedef int PST_SOCK_OPT_VAL_T;
 #define PST_F_SETFL		4	/* Set file status flags.  */
 
 #else
-#define PST_FCNTL_HDR fcntl.h
+#define PST_FCNTL_HDR "fcntl.h"
 #define PST_FCNTL fcntl
 
 #define PST_F_GETFD F_GETFD
@@ -229,60 +227,60 @@ typedef int PST_SOCK_OPT_VAL_T;
     (static_cast<int>((static_cast<unsigned int>((-1)/2))) - (0xded - 97))
 
 
-// Use #include PIST_QUOTE(PST_NETDB_HDR)
+// Use #include PST_NETDB_HDR
 #ifdef _IS_WINDOWS
-#define PST_NETDB_HDR ws2tcpip.h
+#define PST_NETDB_HDR "ws2tcpip.h"
 #else
-#define PST_NETDB_HDR netdb.h
+#define PST_NETDB_HDR "netdb.h"
 #endif
 
-// Use #include PIST_QUOTE(PST_SOCKET_HDR)
+// Use #include PST_SOCKET_HDR
 #ifdef _IS_WINDOWS
-#define PST_SOCKET_HDR winsock2.h
+#define PST_SOCKET_HDR "winsock2.h"
 #else
-#define PST_SOCKET_HDR sys/socket.h
+#define PST_SOCKET_HDR "sys/socket.h"
 #endif
 
-// Use #include PIST_QUOTE(PST_ARPA_INET_HDR)
+// Use #include PST_ARPA_INET_HDR
 #ifdef _IS_WINDOWS
-#define PST_ARPA_INET_HDR winsock2.h
+#define PST_ARPA_INET_HDR "winsock2.h"
 #else
-#define PST_ARPA_INET_HDR arpa/inet.h
+#define PST_ARPA_INET_HDR "arpa/inet.h"
 #endif
 
-// Use #include PIST_QUOTE(PST_NETINET_IN_HDR)
+// Use #include PST_NETINET_IN_HDR
 #ifdef _IS_WINDOWS
-#define PST_NETINET_IN_HDR ws2def.h
+#define PST_NETINET_IN_HDR "ws2def.h"
 #else
-#define PST_NETINET_IN_HDR netinet/in.h
+#define PST_NETINET_IN_HDR "netinet/in.h"
 #endif
 
-// Use #include PIST_QUOTE(PST_NETINET_TCP_HDR)
+// Use #include PST_NETINET_TCP_HDR
 #ifdef _IS_WINDOWS
-#define PST_NETINET_TCP_HDR winsock2.h
+#define PST_NETINET_TCP_HDR "winsock2.h"
 #else
-#define PST_NETINET_TCP_HDR netinet/tcp.h
+#define PST_NETINET_TCP_HDR "netinet/tcp.h"
 #endif
 
 
-// Use #include PIST_QUOTE(PST_IFADDRS_HDR)
+// Use #include PST_IFADDRS_HDR
 #ifdef _IS_WINDOWS
-#define PST_IFADDRS_HDR pistache/pist_ifaddrs.h
+#define PST_IFADDRS_HDR "pistache/pist_ifaddrs.h"
 #define PST_IFADDRS pist_ifaddrs
 #define PST_GETIFADDRS pist_getifaddrs
 #define PST_FREEIFADDRS pist_freeifaddrs
 #else
-#define PST_IFADDRS_HDR ifaddrs.h
+#define PST_IFADDRS_HDR "ifaddrs.h"
 #define PST_IFADDRS ifaddrs
 #define PST_GETIFADDRS getifaddrs
 #define PST_FREEIFADDRS freeifaddrs
 #endif
 
-// Use #include PIST_QUOTE(PST_SYS_UN_HDR)
+// Use #include PST_SYS_UN_HDR
 #ifdef _IS_WINDOWS
-#define PST_SYS_UN_HDR afunix.h
+#define PST_SYS_UN_HDR "afunix.h"
 #else
-#define PST_SYS_UN_HDR sys/un.h
+#define PST_SYS_UN_HDR "sys/un.h"
 #endif
 
 
@@ -300,56 +298,56 @@ typedef struct in_addr PST_IN_ADDR_T;
 
 
 
-// Use #include PIST_QUOTE(PST_THREAD_HDR)
+// Use #include PST_THREAD_HDR
 #ifdef _IS_WINDOWS
 // Note: processthreadsapi.h appears to require the prior inclusion of
 // windows.h as well.
 // So make sure to include PST_THREAD_HDR only in C/C++ files, not in a header
 // file where it could end up including the massive windows.h all over the
 // place.
-#define PST_THREAD_HDR processthreadsapi.h
+#define PST_THREAD_HDR "processthreadsapi.h"
 #else
-#define PST_THREAD_HDR pthread.h
+#define PST_THREAD_HDR "pthread.h"
 #endif
 
-// Use #include PIST_QUOTE(PST_ERRNO_HDR)
+// Use #include PST_ERRNO_HDR
 #ifndef __linux__
 // pistache/pst_errno.h prevents mingw gcc's bad macro substitution on errno
 // Same issue with clang on macOS and gcc on OpenBSD
-#define PST_ERRNO_HDR pistache/pst_errno.h
+#define PST_ERRNO_HDR "pistache/pst_errno.h"
 #else
-#define PST_ERRNO_HDR sys/errno.h
+#define PST_ERRNO_HDR "sys/errno.h"
 #endif
 
-// Use #include PIST_QUOTE(PST_MISC_IO_HDR)
+// Use #include PST_MISC_IO_HDR
 #ifdef _IS_WINDOWS
-#define PST_MISC_IO_HDR io.h
+#define PST_MISC_IO_HDR "io.h"
 // For _close etc.
 #else
-#define PST_MISC_IO_HDR unistd.h
+#define PST_MISC_IO_HDR "unistd.h"
 #endif
 
-// Use #include PIST_QUOTE(PIST_FILEFNS_HDR)
+// Use #include PIST_FILEFNS_HDR
 #ifdef _IS_WINDOWS
-#define PIST_FILEFNS_HDR pistache/pist_filefns.h
+#define PIST_FILEFNS_HDR "pistache/pist_filefns.h"
 #else
 // unistd.h defines pread
-#define PIST_FILEFNS_HDR unistd.h
+#define PIST_FILEFNS_HDR "unistd.h"
 #endif
 
-// Use #include PIST_QUOTE(PIST_POLL_HDR)
+// Use #include PIST_POLL_HDR
 #ifdef _IS_WINDOWS
-#define PIST_POLL_HDR pistache/pist_sockfns.h
+#define PIST_POLL_HDR "pistache/pist_sockfns.h"
 #else
-#define PIST_POLL_HDR poll.h
+#define PIST_POLL_HDR "poll.h"
 #endif
 
-// Use #include PIST_QUOTE(PIST_SOCKFNS_HDR)
+// Use #include PIST_SOCKFNS_HDR
 #ifdef _IS_WINDOWS
-#define PIST_SOCKFNS_HDR pistache/pist_sockfns.h
+#define PIST_SOCKFNS_HDR "pistache/pist_sockfns.h"
 #else
 // unistd.h defines pread
-#define PIST_SOCKFNS_HDR unistd.h // has close, read and write in Linux
+#define PIST_SOCKFNS_HDR "unistd.h" // has close, read and write in Linux
 #endif
 
 // PST_SOCK_xxx macros are for sockets. For files, use PST_FILE_xxx

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -19,14 +19,14 @@
 #include <pistache/net.h>
 #include <pistache/stream.h>
 
-#include PIST_QUOTE(PST_NETDB_HDR)
-#include PIST_QUOTE(PST_SOCKET_HDR)
-#include PIST_QUOTE(PIST_SOCKFNS_HDR)
+#include PST_NETDB_HDR
+#include PST_SOCKET_HDR
+#include PIST_SOCKFNS_HDR
 
 // ps_sendfile.h includes sys/uio.h in macOS, and sys/sendfile.h in Linux
 #include <pistache/ps_sendfile.h>
 
-#include PIST_QUOTE(PST_STRERROR_R_HDR)
+#include PST_STRERROR_R_HDR
 
 #include <sys/types.h>
 

--- a/src/common/eventmeth.cc
+++ b/src/common/eventmeth.cc
@@ -5,7 +5,7 @@
  */
 
 #include <pistache/winornix.h>
-#include PIST_QUOTE(PST_ERRNO_HDR)
+#include PST_ERRNO_HDR
 
 #include <pistache/eventmeth.h>
 #include <pistache/pist_quote.h>
@@ -748,9 +748,9 @@ namespace Pistache
 #include <pistache/pist_timelog.h>
 #include <pistache/os.h>
 
-#include PIST_QUOTE(PST_MISC_IO_HDR) // unistd.h, for close
-#include PIST_QUOTE(PST_FCNTL_HDR)
-#include PIST_QUOTE(PIST_SOCKFNS_HDR) // socket read, write and close
+#include PST_MISC_IO_HDR // unistd.h, for close
+#include PST_FCNTL_HDR
+#include PIST_SOCKFNS_HDR // socket read, write and close
 
 #include <assert.h>
 

--- a/src/common/http.cc
+++ b/src/common/http.cc
@@ -20,7 +20,7 @@
 #include <pistache/peer.h>
 #include <pistache/transport.h>
 
-#include PIST_QUOTE(PST_STRERROR_R_HDR)
+#include PST_STRERROR_R_HDR
 
 #include <charconv>
 #include <cstring>
@@ -33,10 +33,10 @@
 #include <unordered_map>
 
 #include <fcntl.h> // for file-constants (_O_RDONLY etc.) in Windows
-#include PIST_QUOTE(PST_FCNTL_HDR) // for function fcntl()
+#include PST_FCNTL_HDR // for function fcntl()
 
-#include PIST_QUOTE(PST_MISC_IO_HDR) // for _close (io.h / unistd.h)
-#include PIST_QUOTE(PIST_FILEFNS_HDR) // for "open"
+#include PST_MISC_IO_HDR // for _close (io.h / unistd.h)
+#include PIST_FILEFNS_HDR // for "open"
 
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/common/http_defs.cc
+++ b/src/common/http_defs.cc
@@ -24,7 +24,7 @@
 #endif
 #include <pistache/http_defs.h>
 
-#include PIST_QUOTE(PST_CLOCK_GETTIME_HDR)
+#include PST_CLOCK_GETTIME_HDR
 
 namespace Pistache::Http
 {

--- a/src/common/http_header.cc
+++ b/src/common/http_header.cc
@@ -29,7 +29,7 @@
 #include <string>
 #include <string_view>
 
-#include PIST_QUOTE(PST_SOCKET_HDR)
+#include PST_SOCKET_HDR
 
 namespace Pistache::Http::Header
 {

--- a/src/common/net.cc
+++ b/src/common/net.cc
@@ -26,12 +26,12 @@
 
 #include <pistache/ps_strl.h>
 
-#include PIST_QUOTE(PST_ARPA_INET_HDR)
+#include PST_ARPA_INET_HDR
 
-#include PIST_QUOTE(PST_IFADDRS_HDR)
+#include PST_IFADDRS_HDR
 
-#include PIST_QUOTE(PST_NETDB_HDR)
-#include PIST_QUOTE(PST_SOCKET_HDR)
+#include PST_NETDB_HDR
+#include PST_SOCKET_HDR
 
 #include <sys/types.h>
 

--- a/src/common/os.cc
+++ b/src/common/os.cc
@@ -16,8 +16,8 @@
 #include <pistache/config.h>
 #include <pistache/os.h>
 
-#include PIST_QUOTE(PST_FCNTL_HDR)
-#include PIST_QUOTE(PIST_SOCKFNS_HDR)
+#include PST_FCNTL_HDR
+#include PIST_SOCKFNS_HDR
 
 #include <pistache/pist_timelog.h>
 
@@ -27,7 +27,7 @@
 #include <sys/epoll.h>
 #endif
 
-#include PIST_QUOTE(PST_MISC_IO_HDR) // unistd.h e.g. close
+#include PST_MISC_IO_HDR // unistd.h e.g. close
 
 #include <algorithm>
 #include <fstream>

--- a/src/common/peer.cc
+++ b/src/common/peer.cc
@@ -14,9 +14,9 @@
 #include <iostream>
 #include <stdexcept>
 
-#include PIST_QUOTE(PST_ARPA_INET_HDR)
-#include PIST_QUOTE(PST_NETDB_HDR)
-#include PIST_QUOTE(PST_SOCKET_HDR)
+#include PST_ARPA_INET_HDR
+#include PST_NETDB_HDR
+#include PST_SOCKET_HDR
 
 #include <sys/types.h>
 

--- a/src/common/pist_check.cc
+++ b/src/common/pist_check.cc
@@ -18,7 +18,7 @@
 #include <signal.h>
 #include <stdio.h>
 
-#include PIST_QUOTE(PST_MISC_IO_HDR) // unistd.h e.g. close
+#include PST_MISC_IO_HDR // unistd.h e.g. close
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -34,7 +34,7 @@
 #include <dlfcn.h> // Dl_info
 #endif
 
-#include PIST_QUOTE(PST_MAXPATH_HDR) // for PST_MAXPATHLEN
+#include PST_MAXPATH_HDR // for PST_MAXPATHLEN
 
 #include <pistache/ps_basename.h> // for PS_BASENAME_R
 

--- a/src/common/pist_strerror_r.cc
+++ b/src/common/pist_strerror_r.cc
@@ -12,7 +12,16 @@
 #include <string.h>
 #include <algorithm>
 
-#include PIST_QUOTE(PST_ERRNO_HDR)
+// #ifdef errno
+// #error "already defined"
+// #endif
+
+// // PIST_Q(PST_ERRNO_HDR)
+// PST_ERRNO_HDR
+
+
+// #include PST_ERRNO_HDR
+#include PST_ERRNO_HDR
 
 /* ------------------------------------------------------------------------- */
 

--- a/src/common/pist_strerror_r.cc
+++ b/src/common/pist_strerror_r.cc
@@ -12,15 +12,6 @@
 #include <string.h>
 #include <algorithm>
 
-// #ifdef errno
-// #error "already defined"
-// #endif
-
-// // PIST_Q(PST_ERRNO_HDR)
-// PST_ERRNO_HDR
-
-
-// #include PST_ERRNO_HDR
 #include PST_ERRNO_HDR
 
 /* ------------------------------------------------------------------------- */

--- a/src/common/pist_syslog.cc
+++ b/src/common/pist_syslog.cc
@@ -22,7 +22,7 @@
 #include <stdio.h> // snprintf
 #include <stdlib.h> // malloc
 
-#include PIST_QUOTE(PST_CLOCK_GETTIME_HDR)
+#include PST_CLOCK_GETTIME_HDR
 
 #include <time.h>
 #include <string.h>
@@ -39,7 +39,7 @@
 #include <algorithm> // std::remove_copy_if
 #include <vector>
 // #include <limits.h> // PATH_MAX
-#include PIST_QUOTE(PST_MAXPATH_HDR)
+#include PST_MAXPATH_HDR
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h> // _NSGetExecutablePath
@@ -168,12 +168,12 @@
 #include <stdarg.h>
 #include <string.h> // for strcat
 
-#include PIST_QUOTE(PST_THREAD_HDR) // for pthread_self (getting thread ID)
+#include PST_THREAD_HDR // for pthread_self (getting thread ID)
 
-#include PIST_QUOTE(PST_MAXPATH_HDR)
+#include PST_MAXPATH_HDR
 
 #include <sys/types.h> // for getpid()
-#include PIST_QUOTE(PST_MISC_IO_HDR) // unistd.h e.g. close
+#include PST_MISC_IO_HDR // unistd.h e.g. close
 
 #include "pistache/pist_syslog.h"
 #include <memory> // for std::shared_ptr

--- a/src/common/pist_timelog.cc
+++ b/src/common/pist_timelog.cc
@@ -16,7 +16,7 @@
 #ifdef _IS_WINDOWS
 #include <windows.h> // required for PST_THREAD_HDR (processthreadsapi.h)
 #endif
-#include PIST_QUOTE(PST_THREAD_HDR) //e.g. pthread.h
+#include PST_THREAD_HDR //e.g. pthread.h
 
 #ifdef DEBUG
 #include <atomic>

--- a/src/common/reactor.cc
+++ b/src/common/reactor.cc
@@ -25,7 +25,7 @@
 
 #ifdef _IS_BSD
 // For pthread_set_name_np
-#include PIST_QUOTE(PST_THREAD_HDR)
+#include PST_THREAD_HDR
 #ifndef __NetBSD__
 #include <pthread_np.h>
 #endif
@@ -33,7 +33,7 @@
 
 #ifdef _IS_WINDOWS
 #include <windows.h> // Needed for PST_THREAD_HDR (processthreadsapi.h)
-#include PIST_QUOTE(PST_THREAD_HDR) // for SetThreadDescription
+#include PST_THREAD_HDR // for SetThreadDescription
 #endif
 
 #ifdef _IS_WINDOWS

--- a/src/common/stream.cc
+++ b/src/common/stream.cc
@@ -20,12 +20,12 @@
 
 #include <fcntl.h> // Needs this as well in Windows for file-open constants
 
-#include PIST_QUOTE(PST_FCNTL_HDR)
+#include PST_FCNTL_HDR
 
 #include <sys/stat.h>
 #include <sys/types.h>
-#include PIST_QUOTE(PST_MISC_IO_HDR) // unistd.h e.g. close
-#include PIST_QUOTE(PIST_FILEFNS_HDR) // PST_FILE_OPEN
+#include PST_MISC_IO_HDR // unistd.h e.g. close
+#include PIST_FILEFNS_HDR // PST_FILE_OPEN
 
 namespace Pistache
 {

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -12,6 +12,7 @@
 */
 
 #include <pistache/eventmeth.h>
+#include <pistache/pist_quote.h>
 
 #ifdef _USE_LIBEVENT_LIKE_APPLE
 

--- a/src/common/transport.cc
+++ b/src/common/transport.cc
@@ -32,9 +32,9 @@
 // ps_sendfile.h includes sys/uio.h in macOS, and sys/sendfile.h in Linux
 #include <pistache/ps_sendfile.h>
 
-#include PIST_QUOTE(PST_MISC_IO_HDR) // unistd.h/lseek in BSD.
+#include PST_MISC_IO_HDR // unistd.h/lseek in BSD.
 
-#include PIST_QUOTE(PIST_SOCKFNS_HDR) // socket read, write and close
+#include PIST_SOCKFNS_HDR // socket read, write and close
 
 #ifndef _USE_LIBEVENT_LIKE_APPLE
 // Note: sys/timerfd.h is linux-only (and certainly POSIX only)

--- a/src/common/utils.cc
+++ b/src/common/utils.cc
@@ -14,8 +14,8 @@
 
 #include <pistache/peer.h>
 
-#include PIST_QUOTE(PST_MISC_IO_HDR) // unistd.h e.g. close
-#include PIST_QUOTE(PIST_FILEFNS_HDR) // for pist_pread
+#include PST_MISC_IO_HDR // unistd.h e.g. close
+#include PIST_FILEFNS_HDR // for pist_pread
 
 #ifdef PISTACHE_USE_SSL
 

--- a/src/server/endpoint.cc
+++ b/src/server/endpoint.cc
@@ -13,6 +13,7 @@
 #include <pistache/config.h>
 #include <pistache/endpoint.h>
 #include <pistache/peer.h>
+#include <pistache/pist_quote.h>
 #include <pistache/tcp.h>
 
 #include <array>

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -19,22 +19,22 @@
 #include <pistache/ssl_wrappers.h>
 #include <pistache/transport.h>
 
-#include PIST_QUOTE(PST_ARPA_INET_HDR)
-#include PIST_QUOTE(PST_NETDB_HDR)
-#include PIST_QUOTE(PST_NETINET_IN_HDR)
-#include PIST_QUOTE(PST_NETINET_TCP_HDR)
+#include PST_ARPA_INET_HDR
+#include PST_NETDB_HDR
+#include PST_NETINET_IN_HDR
+#include PST_NETINET_TCP_HDR
 
 #include <pistache/eventmeth.h>
 
-#include PIST_QUOTE(PST_MISC_IO_HDR) // unistd.h e.g. close
-#include PIST_QUOTE(PST_FCNTL_HDR)
-#include PIST_QUOTE(PIST_SOCKFNS_HDR) // socket read, write and close
+#include PST_MISC_IO_HDR // unistd.h e.g. close
+#include PST_FCNTL_HDR
+#include PIST_SOCKFNS_HDR // socket read, write and close
 
 #ifndef _USE_LIBEVENT
 #include <sys/epoll.h>
 #endif
 
-#include PIST_QUOTE(PST_SOCKET_HDR)
+#include PST_SOCKET_HDR
 
 #ifndef _USE_LIBEVENT_LIKE_APPLE
 // Note: sys/timerfd.h is linux-only (and certainly POSIX only)

--- a/src/server/listener.cc
+++ b/src/server/listener.cc
@@ -16,6 +16,7 @@
 #include <pistache/listener.h>
 #include <pistache/os.h>
 #include <pistache/peer.h>
+#include <pistache/pist_quote.h>
 #include <pistache/ssl_wrappers.h>
 #include <pistache/transport.h>
 

--- a/tests/helpers_test.cc
+++ b/tests/helpers_test.cc
@@ -13,7 +13,7 @@
 #include <pistache/eventmeth.h>
 #include <pistache/os.h>
 
-#include PIST_QUOTE(PIST_SOCKFNS_HDR) // e.g. unistd.h
+#include PIST_SOCKFNS_HDR // e.g. unistd.h
 
 using namespace Pistache;
 

--- a/tests/listener_test.cc
+++ b/tests/listener_test.cc
@@ -7,18 +7,18 @@
 #include <gtest/gtest.h>
 
 #include <pistache/winornix.h>
-#include PIST_QUOTE(PST_ARPA_INET_HDR)
-#include PIST_QUOTE(PST_NETDB_HDR)
-#include PIST_QUOTE(PST_NETINET_IN_HDR)
+#include PST_ARPA_INET_HDR
+#include PST_NETDB_HDR
+#include PST_NETINET_IN_HDR
 
 
 #include <errno.h>
 #include <stdlib.h>
-#include PIST_QUOTE(PST_SOCKET_HDR)
-#include PIST_QUOTE(PIST_SOCKFNS_HDR)
+#include PST_SOCKET_HDR
+#include PIST_SOCKFNS_HDR
 
 #include <sys/types.h>
-#include PIST_QUOTE(PST_MISC_IO_HDR) // unistd.h
+#include PST_MISC_IO_HDR // unistd.h
 
 #include <array>
 #include <sstream>

--- a/tests/net_test.cc
+++ b/tests/net_test.cc
@@ -14,10 +14,10 @@
 #include <iostream>
 #include <stdexcept>
 
-#include PIST_QUOTE(PST_ARPA_INET_HDR)
-#include PIST_QUOTE(PST_NETDB_HDR)
-#include PIST_QUOTE(PST_NETINET_IN_HDR)
-#include PIST_QUOTE(PST_SYS_UN_HDR)
+#include PST_ARPA_INET_HDR
+#include PST_NETDB_HDR
+#include PST_NETINET_IN_HDR
+#include PST_SYS_UN_HDR
 
 using namespace Pistache;
 using testing::Eq;

--- a/tests/tcp_client.h
+++ b/tests/tcp_client.h
@@ -10,9 +10,9 @@
 #include <pistache/net.h>
 #include <pistache/os.h>
 
-#include PIST_QUOTE(PST_NETDB_HDR)
-#include PIST_QUOTE(PIST_POLL_HDR)
-#include PIST_QUOTE(PST_SOCKET_HDR) // best in C/C++, not .h, for non-test code
+#include PST_NETDB_HDR
+#include PIST_POLL_HDR
+#include PST_SOCKET_HDR // best in C/C++, not .h, for non-test code
 
 #include <sys/types.h>
 


### PR DESCRIPTION
Use strings in include strings definitions to avoid replacements by macros. This solves the issues with errno.h which could have end up in  strange include errors, before.

(Close #1267)