### PR TITLE
Fix: Date header parsing when date is an epoch

### DIFF
--- a/src/common/http_defs.cc
+++ b/src/common/http_defs.cc
@@ -62,6 +62,26 @@ namespace Pistache::Http
             return !in.fail();
         }
 
+        bool parse_epoch(const std::string& s, time_point& tp)
+        {
+            for (unsigned int i = 0; i < s.size(); ++i)
+            {
+                if (!std::isdigit(s[i]))
+                    return false;
+            }
+
+            try
+            {
+                tp = time_point(std::chrono::seconds(std::stoull(s)));
+            }
+            catch (std::out_of_range& e)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
     } // anonymous namespace
 
     CacheDirective::CacheDirective(Directive directive)
@@ -126,6 +146,8 @@ namespace Pistache::Http
         else if (parse_RFC_850(str, tp))
             return FullDate(tp);
         else if (parse_asctime(str, tp))
+            return FullDate(tp);
+        else if (parse_epoch(str, tp))
             return FullDate(tp);
 
         PS_LOG_DEBUG_ARGS("Failed parsing date: %s", str.c_str());


### PR DESCRIPTION
The Date header sometimes is an epoch (e.g. git)

Handle such cases instead of dropping the request.

Tested locally, works fine.